### PR TITLE
Manual version bump to 0.0.8

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
semantic-release action doesn't allow major version 0 (https://github.com/semantic-release/semantic-release/issues/1507)