### PR TITLE
3y25n4z - Add Util to get the installed admin app package name

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
+++ b/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
@@ -175,4 +175,17 @@ public class NativeUtils {
             mContext.sendBroadcast(i);
         } catch (Exception e) {}
     }
+
+    public String getInstalledAdminAppPackageName() {
+        PackageManager pm = context.getPackageManager();
+        List<PackageInfo> packages = pm.getInstalledPackages(0);
+
+        for (PackageInfo packageInfo : packages) {
+            if (packageInfo.packageName.startsWith("com.mightyimmersion.mightyplatform.adminapp") && !packageInfo.packageName.contains("preload")) {
+                return packageInfo.packageName;
+            }
+        }
+        return null;
+    }
+
 }

--- a/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
+++ b/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
@@ -177,7 +177,7 @@ public class NativeUtils {
     }
 
     public String getInstalledAdminAppPackageName() {
-        PackageManager pm = context.getPackageManager();
+        PackageManager pm = mContext.getPackageManager();
         List<PackageInfo> packages = pm.getInstalledPackages(0);
 
         for (PackageInfo packageInfo : packages) {

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -58,5 +58,11 @@ namespace MXR.SDK {
             KillApp(packageName);
             LaunchAppWithPackageName(packageName);
         }
+
+        public static string GetAdminAppPackageName() {
+            if (Plugin != null)
+                return Plugin.Call<string>("getInstalledAdminAppPackageName");
+            return null;
+        }
     }
 }


### PR DESCRIPTION
We sometimes need to know which version of the admin app (aka package) we are talking to. This PR adds an AndroidUtil that will retrieve this packageName (or null). 