### PR TITLE
Bump to 1.0.1 | Merge only after PR #13 !

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
Once merged, we'll create a new git tag for `v1.0.1` so that openupm can pick it up. PR #13 will fix an important missing readme meta file that seems to prevent Unity builds. CI currently doesn't auto bump semantic release, but that can be enabled after this so that tags will be automatically created and picked up by OpenUPM