### PR TITLE
Added RuntimeSettingsSummary.isPasscodeEnabled

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -155,6 +155,12 @@ namespace MXR.SDK {
         public bool disableShortcutMenu = false;
 
         /// <summary>
+        /// Whether device passcode has been enabled on the configuration this device
+        /// uses.
+        /// </summary>
+        public bool isPasscodeEnabled = false;
+
+        /// <summary>
         /// The settings that are not to be made editable in the launcher
         /// </summary>
         public HiddenSettings hiddenSettings = new HiddenSettings();

--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -26,7 +26,7 @@ namespace MXR.SDK {
         /// Whether device passcode has been enabled on the configuration this device
         /// uses. 
         /// </summary>
-        public bool isPasscodeEnabled = false;
+        public bool isPasscodeEnabled;
 
         /// <summary>
         /// The ManageXR organization this device is under

--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -20,7 +20,13 @@ namespace MXR.SDK {
         /// <summary>
         /// The name of the device as set on the ManageXR portal
         /// </summary>
-        public string deviceName;
+        public string deviceName; 
+
+        /// <summary>
+        /// Whether device passcode has been enabled on the configuration this device
+        /// uses. 
+        /// </summary>
+        public bool isPasscodeEnabled = false;
 
         /// <summary>
         /// The ManageXR organization this device is under
@@ -153,12 +159,6 @@ namespace MXR.SDK {
         /// is set to <see cref="DeviceExperienceMode.HOME_SCREEN"/>
         /// </summary>
         public bool disableShortcutMenu = false;
-
-        /// <summary>
-        /// Whether device passcode has been enabled on the configuration this device
-        /// uses.
-        /// </summary>
-        public bool isPasscodeEnabled = false;
 
         /// <summary>
         /// The settings that are not to be made editable in the launcher


### PR DESCRIPTION
isPasscodeEnabled boolean is true when passcodes have been enabled on the Device Settings tab. Can be used to show a lock button when the device can be locked.