### PR TITLE
Add lastForegroundAppForShortcutMenu field to DeviceStatus

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -61,6 +61,7 @@ namespace MXR.SDK {
         public Dictionary<string, FileInstallStatus> fileStatuses = new Dictionary<string, FileInstallStatus>();
         public Timestamp lastCheckIn = new Timestamp();
         public Timestamp lastUpdate = new Timestamp();
+        public ForegroundAppForShortcutMenu lastForegroundAppForShortcutMenu = new ForegroundAppForShortcutMenu();
         
         /// <summary>
         /// Returns the <see cref="FileInstallStatus"/> for a <see cref="Video"/>
@@ -121,6 +122,13 @@ namespace MXR.SDK {
     public class ForegroundApp {
         public string packageName;
         public string className;
+    }
+
+    [System.Serializable]
+    public class ForegroundAppForShortcutMenu {
+        public string packageName;
+        public string className;
+        public Timestamp lastUpdated = new Timestamp();
     }
 
     /// <summary>

--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -56,6 +56,10 @@ namespace MXR.SDK {
 
         public bool picoCvControllerUpdateAvailable;
         public bool picoGuardianHasBeenOpened;
+        
+        /// <summary>
+        /// The last app open in the foregound that is appropriate to show in the shortcut menu.
+        /// </summary>
         public ForegroundAppForShortcutMenu lastForegroundAppForShortcutMenu = new ForegroundAppForShortcutMenu();
         public bool oculusScreencastActive;
         public ForegroundApp currentForegroundApp = new ForegroundApp();
@@ -127,6 +131,10 @@ namespace MXR.SDK {
 
     [System.Serializable]
     public class ForegroundAppForShortcutMenu : ForegroundApp {
+        /// <summary>
+        /// The last time this object was updated. This represents the time that this foreground
+        /// app was first detected in the foreground.
+        /// </summary>
         public Timestamp lastUpdated = new Timestamp();
     }
 

--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -56,12 +56,12 @@ namespace MXR.SDK {
 
         public bool picoCvControllerUpdateAvailable;
         public bool picoGuardianHasBeenOpened;
+        public ForegroundAppForShortcutMenu lastForegroundAppForShortcutMenu = new ForegroundAppForShortcutMenu();
         public ForegroundApp currentForegroundApp = new ForegroundApp();
         public ForegroundApp previousForegroundApp = new ForegroundApp();
         public Dictionary<string, FileInstallStatus> fileStatuses = new Dictionary<string, FileInstallStatus>();
         public Timestamp lastCheckIn = new Timestamp();
         public Timestamp lastUpdate = new Timestamp();
-        public ForegroundAppForShortcutMenu lastForegroundAppForShortcutMenu = new ForegroundAppForShortcutMenu();
         
         /// <summary>
         /// Returns the <see cref="FileInstallStatus"/> for a <see cref="Video"/>
@@ -125,9 +125,7 @@ namespace MXR.SDK {
     }
 
     [System.Serializable]
-    public class ForegroundAppForShortcutMenu {
-        public string packageName;
-        public string className;
+    public class ForegroundAppForShortcutMenu : ForegroundApp {
         public Timestamp lastUpdated = new Timestamp();
     }
 


### PR DESCRIPTION
This field is used to help the home screen determine which approved app was last in the foreground