### PR TITLE
Added Enterprise Wifi Network functionality to SDK

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -176,14 +176,8 @@ public class AdminAppMessengerManager {
         return sendMessage(AdminAppMessageTypes.CONNECT_TO_WIFI_NETWORK, "{\"ssid\": \""+ssid+"\", \"password\":\""+password+"\" }");
     }
 
-    public boolean connectToEnterpriseWifiNetworkAsync(Sring ssid, String password, String identity, String eapMethod, String phase2AuthenticationMethod, String anonymousIdentity, String domain {
-        if (password == null) password = "";
-        if (identity == null) identity = "";
-        if (eapMethod == null) eapMethod = "";
-        if (phase2AuthenticationMethod == null) phase2AuthenticationMethod = "";
-        if (anonymousIdentity == null) anonymousIdentity = "";
-        if (domain == null) domain = "";
-        return sendMessage(AdminAppMessageTypes.CONNECT_TO_WIFI_NETWORK, "{\"ssid\": \""+ssid+"\", \"password\":\""+password+"\", \"identity\":\""+identity+"\", \"eapMethod\":\""+eapMethod+"\", \"phase2AuthenticationMethod\":\""+phase2AuthenticationMethod+"\", \"anonymousIdentity\":\""+anonymousIdentity+"\", \"domain\":\""+domain+"\"}");
+    public boolean connectToEnterpriseWifiNetworkAsync(String requestJson) {
+        return sendMessage(AdminAppMessageTypes.CONNECT_TO_WIFI_NETWORK, requestJson);
     }
 
     public boolean forgetWifiNetworkAsync(String ssid) {

--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -176,6 +176,16 @@ public class AdminAppMessengerManager {
         return sendMessage(AdminAppMessageTypes.CONNECT_TO_WIFI_NETWORK, "{\"ssid\": \""+ssid+"\", \"password\":\""+password+"\" }");
     }
 
+    public boolean connectToEnterpriseWifiNetworkAsync(Sring ssid, String password, String identity, String eapMethod, String phase2AuthenticationMethod, String anonymousIdentity, String domain {
+        if (password == null) password = "";
+        if (identity == null) identity = "";
+        if (eapMethod == null) eapMethod = "";
+        if (phase2AuthenticationMethod == null) phase2AuthenticationMethod = "";
+        if (anonymousIdentity == null) anonymousIdentity = "";
+        if (domain == null) domain = "";
+        return sendMessage(AdminAppMessageTypes.CONNECT_TO_WIFI_NETWORK, "{\"ssid\": \""+ssid+"\", \"password\":\""+password+"\", \"identity\":\""+identity+"\", \"eapMethod\":\""+eapMethod+"\", \"phase2AuthenticationMethod\":\""+phase2AuthenticationMethod+"\", \"anonymousIdentity\":\""+anonymousIdentity+"\", \"domain\":\""+domain+"\"}");
+    }
+
     public boolean forgetWifiNetworkAsync(String ssid) {
         return sendMessage(AdminAppMessageTypes.FORGET_WIFI_NETWORK, "{\"ssid\":\""+ssid+"\"}");
     }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,4 +1,5 @@
 #define UNITY_ANDROID
+//TODO : ^ remove post testing 
 #if UNITY_ANDROID
 using System;
 using System.Collections.Generic;
@@ -286,6 +287,7 @@ namespace MXR.SDK {
                     Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Phase2Method.ToString());
                     Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.AnonymousIdentity);
                     Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Domain);
+                    //TODO : ^ remove post testing 
                 messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,4 +1,4 @@
- #if UNITY_ANDROID
+#if UNITY_ANDROID
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -279,6 +279,13 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.ssid);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.password);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.identity);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.eapMethod.ToString());
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.phase2Method.ToString());
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.anonymousIdentity);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.domain);
                 messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -272,17 +272,21 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiNetwork ignored. System is not available (not bound to messenger.");
         }
 
-           public void ConnectToWifiEnterpriseNetwork(string ssid, string password) {
+           public void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain) {
             ssid = EscapeStringToJsonString(ssid);
             password = EscapeStringToJsonString(password);
+            eapMethod = EscapeStringToJsonString(eapMethod);
+            phase2AuthenticationMethod = EscapeStringToJsonString(phase2AuthenticationMethod);
+            anonymousIdentity = EscapeStringToJsonString(anonymousIdentity);
+            domain = EscapeStringToJsonString(domain);
 
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
-                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiNetwork called. Invoking over JNI: connectToWifiNetworkAsync");
-                messenger.Call<bool>("connectToWifiNetworkAsync", ssid, password);
+                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiEnterpriseNetwork called. Invoking over JNI: connectToWifiNetworkAsync");
+                messenger.Call<bool>("connectToWifiNetworkAsync", ssid, password, identity, eapMethod, phase2AuthenticationMethod, anonymousIdentity, domain);
             }
             else if (LoggingEnabled)
-                Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiNetwork ignored. System is not available (not bound to messenger.");
+                Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiEnterpriseNetwork ignored. System is not available (not bound to messenger.");
         }
 
         public void DisableWifi() {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -6,7 +6,6 @@ using System.IO;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 using UnityEngine;
 
 namespace MXR.SDK {
@@ -272,21 +271,18 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiNetwork ignored. System is not available (not bound to messenger.");
         }
 
-        public void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain) {
-            ssid = EscapeStringToJsonString(ssid);
-            password = EscapeStringToJsonString(password);
-            eapMethod = EscapeStringToJsonString(eapMethod);
-            phase2AuthenticationMethod = EscapeStringToJsonString(phase2AuthenticationMethod);
-            anonymousIdentity = EscapeStringToJsonString(anonymousIdentity);
-            domain = EscapeStringToJsonString(domain);
+        public void ConnectToEnterpriseWifiNetwork(EnterpriseWifiConnectionRequest enterpriseWifiConnectionRequest) {
+
+            if(enterpriseWifiConnectionRequest == null)
+                throw new ArgumentNullException(nameof(enterpriseWifiConnectionRequest));
 
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
-                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiEnterpriseNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                messenger.Call<bool>("connectToWifiNetworkAsync", ssid, password, identity, eapMethod, phase2AuthenticationMethod, anonymousIdentity, domain);
+                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
+                messenger.Call<bool>("connectToWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)
-                Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiEnterpriseNetwork ignored. System is not available (not bound to messenger.");
+                Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToEnterpriseWifiNetwork ignored. System is not available (not bound to messenger.");
         }
 
         public void DisableWifi() {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,6 +1,4 @@
-#define UNITY_ANDROID
-//TODO : ^ remove post testing 
-#if UNITY_ANDROID
+ #if UNITY_ANDROID
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -280,14 +278,6 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Ssid);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Password);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Identity);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.EapMethod.ToString());
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Phase2Method.ToString());
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.AnonymousIdentity);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Domain);
-                    //TODO : ^ remove post testing 
                 messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,3 +1,4 @@
+#define UNITY_ANDROID
 #if UNITY_ANDROID
 using System;
 using System.Collections.Generic;
@@ -259,6 +260,19 @@ namespace MXR.SDK {
         }
 
         public void ConnectToWifiNetwork(string ssid, string password) {
+            ssid = EscapeStringToJsonString(ssid);
+            password = EscapeStringToJsonString(password);
+
+            if (messenger.IsBoundToService) {
+                if (LoggingEnabled)
+                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiNetwork called. Invoking over JNI: connectToWifiNetworkAsync");
+                messenger.Call<bool>("connectToWifiNetworkAsync", ssid, password);
+            }
+            else if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiNetwork ignored. System is not available (not bound to messenger.");
+        }
+
+           public void ConnectToWifiEnterpriseNetwork(string ssid, string password) {
             ssid = EscapeStringToJsonString(ssid);
             password = EscapeStringToJsonString(password);
 

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -278,7 +278,7 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
+                messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonConvert.SerializeObject(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToEnterpriseWifiNetwork ignored. System is not available (not bound to messenger.");

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -279,7 +279,7 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                messenger.Call<bool>("connectToWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
+                messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToEnterpriseWifiNetwork ignored. System is not available (not bound to messenger.");

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -279,13 +279,13 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.ssid);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.password);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.identity);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.eapMethod.ToString());
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.phase2Method.ToString());
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.anonymousIdentity);
-                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.domain);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Ssid);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Password);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Identity);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.EapMethod.ToString());
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Phase2Method.ToString());
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.AnonymousIdentity);
+                    Debug.unityLogger.Log(LogType.Log, TAG, enterpriseWifiConnectionRequest.Domain);
                 messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonUtility.ToJson(enterpriseWifiConnectionRequest));
             }
             else if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
@@ -278,7 +279,8 @@ namespace MXR.SDK {
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
                     Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToEnterpriseWifiNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
-                messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", JsonConvert.SerializeObject(enterpriseWifiConnectionRequest));
+                string json = JsonConvert.SerializeObject(enterpriseWifiConnectionRequest, Formatting.None, new StringEnumConverter());
+                messenger.Call<bool>("connectToEnterpriseWifiNetworkAsync", json);
             }
             else if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToEnterpriseWifiNetwork ignored. System is not available (not bound to messenger.");

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -272,7 +272,7 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Warning, TAG, "ConnectToWifiNetwork ignored. System is not available (not bound to messenger.");
         }
 
-           public void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain) {
+        public void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain) {
             ssid = EscapeStringToJsonString(ssid);
             password = EscapeStringToJsonString(password);
             eapMethod = EscapeStringToJsonString(eapMethod);
@@ -282,7 +282,7 @@ namespace MXR.SDK {
 
             if (messenger.IsBoundToService) {
                 if (LoggingEnabled)
-                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiEnterpriseNetwork called. Invoking over JNI: connectToWifiNetworkAsync");
+                    Debug.unityLogger.Log(LogType.Log, TAG, "ConnectToWifiEnterpriseNetwork called. Invoking over JNI: connectToEnterpriseWifiNetworkAsync");
                 messenger.Call<bool>("connectToWifiNetworkAsync", ssid, password, identity, eapMethod, phase2AuthenticationMethod, anonymousIdentity, domain);
             }
             else if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -245,7 +245,7 @@ namespace MXR.SDK {
         {
             // Escape JSON string. Ref: https://stackoverflow.com/a/26152046
             // Then get rid of the encosing double quotes (") using substring
-            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest.Ssid);
+            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest.ssid);
             ssid = ssid.Substring(1, ssid.Length - 2);
 
             if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -241,6 +241,30 @@ namespace MXR.SDK {
             }
         }
 
+
+        public void ConnectToEnterpriseWifiNetwork(string ssid, string password)
+        {
+            // Escape JSON string. Ref: https://stackoverflow.com/a/26152046
+            // Then get rid of the encosing double quotes (") using substring
+            ssid = JsonConvert.ToString(ssid);
+            ssid = ssid.Substring(1, ssid.Length - 2);
+
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Log, TAG, "Connecting to Wifi Network with SSID " + ssid + " using password " + password);
+
+            // If a network with the given SSID is available
+            // just set it as the current network
+            foreach (var network in WifiNetworks)
+            {
+                if (network.ssid.Equals(ssid))
+                {
+                    CurrentNetwork = network;
+                    if (LoggingEnabled)
+                        Debug.unityLogger.Log(LogType.Log, TAG, "Connected to Wifi Network with SSID " + ssid);
+                }
+            }
+        }
+
         /// <summary>
         /// Currently, in editor, we can only forget the current network.
         /// TODO: Add savedWifiNetworks.json to simulate this function better.

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -241,16 +241,17 @@ namespace MXR.SDK {
             }
         }
 
-
-        public void ConnectToEnterpriseWifiNetwork(string ssid, string password)
+        public void ConnectToEnterpriseWifiNetwork(EnterpriseWifiConnectionRequest enterpriseWifiConnectionRequest)
         {
             // Escape JSON string. Ref: https://stackoverflow.com/a/26152046
             // Then get rid of the encosing double quotes (") using substring
-            ssid = JsonConvert.ToString(ssid);
+            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest);
             ssid = ssid.Substring(1, ssid.Length - 2);
 
             if (LoggingEnabled)
-                Debug.unityLogger.Log(LogType.Log, TAG, "Connecting to Wifi Network with SSID " + ssid + " using password " + password);
+            {
+                Debug.unityLogger.Log(LogType.Log, TAG, "Connecting to Enterprise Wifi Network with SSID " + ssid);
+            }
 
             // If a network with the given SSID is available
             // just set it as the current network
@@ -260,7 +261,7 @@ namespace MXR.SDK {
                 {
                     CurrentNetwork = network;
                     if (LoggingEnabled)
-                        Debug.unityLogger.Log(LogType.Log, TAG, "Connected to Wifi Network with SSID " + ssid);
+                        Debug.unityLogger.Log(LogType.Log, TAG, "Connected to Enterprise Wifi Network with SSID " + ssid);
                 }
             }
         }
@@ -436,6 +437,7 @@ namespace MXR.SDK {
                 throw new DirectoryNotFoundException("Ensure Files/MightyImmersion directory inside Unity project");
             return Path.Combine(mightyDir, fileName);
         }
+        
         #endregion
     }
 }

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -245,7 +245,7 @@ namespace MXR.SDK {
         {
             // Escape JSON string. Ref: https://stackoverflow.com/a/26152046
             // Then get rid of the encosing double quotes (") using substring
-            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest.ssid);
+            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest.Ssid);
             ssid = ssid.Substring(1, ssid.Length - 2);
 
             if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -245,7 +245,7 @@ namespace MXR.SDK {
         {
             // Escape JSON string. Ref: https://stackoverflow.com/a/26152046
             // Then get rid of the encosing double quotes (") using substring
-            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest);
+            var ssid = JsonConvert.ToString(enterpriseWifiConnectionRequest.ssid);
             ssid = ssid.Substring(1, ssid.Length - 2);
 
             if (LoggingEnabled)

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -148,6 +148,16 @@ namespace MXR.SDK {
         /// <param name="password">The password to use to attempt to connect</param>
         void ConnectToWifiNetwork(string ssid, string password);
 
+        ///// <summary>
+        ///// Connects to an Enterpirse wifi network
+        ///// </summary>
+        ///// <param name="ssid">The SSID of the network to connect to</param>
+        ///// <param name="password">The password to use to attempt to connect</param>
+        ///// <param name="identity">The identity to use to attempt to connect</param>
+        ///// <param name="phase2AuthenticationMethod">The phase 2 Authentication Method to use to attempt to connect</param>
+        ///// <param name="anonymousIdentity">The Anonymous Identity to use to attempt to connect</param>
+        //void ConnectToEnterpriseWifiNetwork(string ssid, string password, string identity, string phase2AuthenticationMethod, string anonymousIdentity, string domain);
+        
         /// <summary>
         /// Disable the wifi device
         /// </summary>

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -151,14 +151,8 @@ namespace MXR.SDK {
         ///// <summary>
         ///// Connects to an Enterpirse wifi network
         ///// </summary>
-        ///// <param name="ssid">The SSID of the network to connect to</param>
-        ///// <param name="password">The password to use to attempt to connect</param>
-        ///// <param name="identity">The identity to use to attempt to connect</param>
-        ///// <param name="eapMethod">The EAP Method to use to attempt to connect</param>
-        ///// <param name="phase2AuthenticationMethod">The phase 2 Authentication Method to use to attempt to connect</param>
-        ///// <param name="anonymousIdentity">The Anonymous Identity to use to attempt to connect</param>
-        ///// <param name="domain">The domain to use to attempt to connect</param>
-        void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain);
+        ///// <param name="ssid">The payload for the Enterprise Wifi Connection Request</param>
+        void ConnectToEnterpriseWifiNetwork(EnterpriseWifiConnectionRequest enterpriseWifiConnectionRequest);
 
         /// <summary>
         /// Disable the wifi device

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -154,10 +154,12 @@ namespace MXR.SDK {
         ///// <param name="ssid">The SSID of the network to connect to</param>
         ///// <param name="password">The password to use to attempt to connect</param>
         ///// <param name="identity">The identity to use to attempt to connect</param>
+        ///// <param name="eapMethod">The EAP Method to use to attempt to connect</param>
         ///// <param name="phase2AuthenticationMethod">The phase 2 Authentication Method to use to attempt to connect</param>
         ///// <param name="anonymousIdentity">The Anonymous Identity to use to attempt to connect</param>
-        //void ConnectToEnterpriseWifiNetwork(string ssid, string password, string identity, string phase2AuthenticationMethod, string anonymousIdentity, string domain);
-        
+        ///// <param name="domain">The domain to use to attempt to connect</param>
+        void ConnectToWifiEnterpriseNetwork(string ssid, string password, string identity, string eapMethod, string phase2AuthenticationMethod, string anonymousIdentity, string domain);
+
         /// <summary>
         /// Disable the wifi device
         /// </summary>

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+
 using Newtonsoft.Json;
 
 namespace MXR.SDK {
@@ -311,15 +313,19 @@ namespace MXR.SDK {
         public string ssid;
         public string password;
         public string identity;
+
         public EapMethod eapMethod;
         public Phase2Method phase2Method;
+
+        [DefaultValue("")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string anonymousIdentity = string.Empty;
+
+        [DefaultValue("")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string domain = string.Empty;
 
-        public EnterpriseWifiConnectionRequest()
-        {
-
-        }
+        public EnterpriseWifiConnectionRequest() { }
 
         public EnterpriseWifiConnectionRequest(string ssid, string password, string identity, EapMethod eapMethod, Phase2Method phase2AuthenticationMethod, string anonymousIdentity, string domain)
         {

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -308,13 +308,13 @@ namespace MXR.SDK {
     [Serializable]
     public class EnterpriseWifiConnectionRequest
     {
-        public string ssid;
-        public string password;
-        public string identity;
-        public EapMethod eapMethod;
-        public Phase2Method phase2Method;
-        public string anonymousIdentity;
-        public string domain;
+        public string Ssid;
+        public string Password;
+        public string Identity;
+        public EapMethod EapMethod;
+        public Phase2Method Phase2Method;
+        public string AnonymousIdentity;
+        public string Domain;
 
         public EnterpriseWifiConnectionRequest()
         {
@@ -324,13 +324,13 @@ namespace MXR.SDK {
         public EnterpriseWifiConnectionRequest(string ssid, string password, string identity, EapMethod eapMethod, Phase2Method phase2AuthenticationMethod, string anonymousIdentity, string domain)
         {
             //Only throw exceptions for required fields 
-            this.ssid = ssid ?? throw new ArgumentNullException(nameof(ssid));
-            this.password = password ?? throw new ArgumentNullException(nameof(password));
-            this.identity = identity ?? throw new ArgumentNullException(nameof(identity));
-            this.eapMethod = eapMethod;
-            this.phase2Method = phase2AuthenticationMethod;
-            this.anonymousIdentity = anonymousIdentity;
-            this.domain = domain;
+            this.Ssid = ssid ?? throw new ArgumentNullException(nameof(ssid));
+            this.Password = password ?? throw new ArgumentNullException(nameof(password));
+            this.Identity = identity ?? throw new ArgumentNullException(nameof(identity));
+            this.EapMethod = eapMethod;
+            this.Phase2Method = phase2AuthenticationMethod;
+            this.AnonymousIdentity = anonymousIdentity;
+            this.Domain = domain;
         }
     }
 

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -308,13 +308,13 @@ namespace MXR.SDK {
     [Serializable]
     public class EnterpriseWifiConnectionRequest
     {
-        public string Ssid;
-        public string Password;
-        public string Identity;
-        public EapMethod EapMethod;
-        public Phase2Method Phase2Method;
-        public string AnonymousIdentity;
-        public string Domain;
+        public string ssid;
+        public string password;
+        public string identity;
+        public EapMethod eapMethod;
+        public Phase2Method phase2Method;
+        public string anonymousIdentity;
+        public string domain;
 
         public EnterpriseWifiConnectionRequest()
         {
@@ -324,13 +324,13 @@ namespace MXR.SDK {
         public EnterpriseWifiConnectionRequest(string ssid, string password, string identity, EapMethod eapMethod, Phase2Method phase2AuthenticationMethod, string anonymousIdentity, string domain)
         {
             //Only throw exceptions for required fields 
-            this.Ssid = ssid ?? throw new ArgumentNullException(nameof(ssid));
-            this.Password = password ?? throw new ArgumentNullException(nameof(password));
-            this.Identity = identity ?? throw new ArgumentNullException(nameof(identity));
-            this.EapMethod = eapMethod;
-            this.Phase2Method = phase2AuthenticationMethod;
-            this.AnonymousIdentity = anonymousIdentity;
-            this.Domain = domain;
+            this.ssid = ssid ?? throw new ArgumentNullException(nameof(ssid));
+            this.password = password ?? throw new ArgumentNullException(nameof(password));
+            this.identity = identity ?? throw new ArgumentNullException(nameof(identity));
+            this.eapMethod = eapMethod;
+            this.phase2Method = phase2AuthenticationMethod;
+            this.anonymousIdentity = anonymousIdentity;
+            this.domain = domain;
         }
     }
 

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace MXR.SDK {
     /// <summary>
-    /// Network types. 1-1 Mapping enum with Android native type
+    /// Network types.
     /// </summary>
     [Serializable]
     public enum NetworkType {
@@ -289,4 +289,50 @@ namespace MXR.SDK {
         [JsonIgnore]
         public bool IsOpen => networkSecurityType == NetworkType.OPEN;
     }
+
+    public enum EapMethod
+    {
+        EAP,
+        TTLS,
+        PWD,
+    }
+
+    public enum Phase2Method
+    {
+        PAP,
+        MSCHAP,
+        MSCHAPV2,
+        GTC
+    }
+
+    [Serializable]
+    public class EnterpriseWifiConnectionRequest
+    {
+        public string ssid;
+        public string password;
+        public string identity;
+        public EapMethod eapMethod;
+        public Phase2Method phase2Method;
+        public string anonymousIdentity;
+        public string domain;
+
+        public EnterpriseWifiConnectionRequest()
+        {
+
+        }
+
+        public EnterpriseWifiConnectionRequest(string ssid, string password, string identity, EapMethod eapMethod, Phase2Method phase2AuthenticationMethod, string anonymousIdentity, string domain)
+        {
+            //Only throw exceptions for required fields 
+            this.ssid = ssid ?? throw new ArgumentNullException(nameof(ssid));
+            this.password = password ?? throw new ArgumentNullException(nameof(password));
+            this.identity = identity ?? throw new ArgumentNullException(nameof(identity));
+            this.eapMethod = eapMethod;
+            this.phase2Method = phase2AuthenticationMethod;
+            this.anonymousIdentity = anonymousIdentity;
+            this.domain = domain;
+        }
+    }
+
+
 }

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -313,8 +313,8 @@ namespace MXR.SDK {
         public string identity;
         public EapMethod eapMethod;
         public Phase2Method phase2Method;
-        public string anonymousIdentity;
-        public string domain;
+        public string anonymousIdentity = string.Empty;
+        public string domain = string.Empty;
 
         public EnterpriseWifiConnectionRequest()
         {

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -292,7 +292,7 @@ namespace MXR.SDK {
 
     public enum EapMethod
     {
-        EAP,
+        PEAP,
         TTLS,
         PWD,
     }


### PR DESCRIPTION
Implemented Enterprise Wifi Network functionality so that the Home Screen can send payloads for the `EnterpriseWifiConnectionRequest`to the Admin app

Added `ConnectToWifiEnterpriseNetwork` interface function to `IMXRSystem`

Removed superfluous comment from `NetworkType`



Other notes, could we eventually refactor our interface functions so that each function has a prefix of `I`




