### PR TITLE
Fallback on messenger to init if no storage permissions found

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -500,7 +500,8 @@ namespace MXR.SDK {
 
         const string EXTERNAL_STORAGE_MANAGER_WARNING_MSG =
             "On Android 30 and above, request Manage All Files permission to read local files. " +
-            "A helper method MXRAndroidUtils.RequestManageAllFilesPermission() is provided in the SDK for the same. ";
+            "A helper method MXRAndroidUtils.RequestManageAllFilesPermission() is provided in the SDK for the same. " +
+            "Refer to the MXR Unity SDK README for more info.";
     }
 }
 #endif

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -564,12 +564,8 @@ namespace MXR.SDK {
                 // If we're on level 29 and below, we don't need external storage manager permissions
                 if (!MXRAndroidUtils.NeedsManageAllFilesPermission)
                     return true;
-                else {
-                    if (MXRAndroidUtils.IsExternalStorageManager)
-                        return true;
-                    else
-                        return false;
-                }
+                else 
+                    return MXRAndroidUtils.IsExternalStorageManager;
             }
         }
 

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -498,7 +498,7 @@ namespace MXR.SDK {
             if (LoggingEnabled)
                 Debug.unityLogger.LogWarning(TAG, "RuntimeSettingsSummary cannot initialize using external json file. "
                 + "Trying to initialize it using the cached json file. This is not an error. "
-                + EXTERNAL_STORAGE_MANAGER_WARNING_MSG);
+                + EXTERNAL_READ_WARNING_MSG);
             filePath = _cachedRuntimeSettingsSummaryPath;
 
             if (InitFromFile(filePath)) {
@@ -554,7 +554,7 @@ namespace MXR.SDK {
             if (LoggingEnabled)
                 Debug.unityLogger.LogWarning(TAG, "DeviceStatus cannot initialize using external json file. "
                 + "Trying to initialize it using the cached json file. This is not an error. "
-                + EXTERNAL_STORAGE_MANAGER_WARNING_MSG);
+                + EXTERNAL_READ_WARNING_MSG);
             filePath = _cachedDeviceStatusPath;
 
             if (InitFromFile(filePath)) {
@@ -625,9 +625,10 @@ namespace MXR.SDK {
             return output;
         }
 
-        const string EXTERNAL_STORAGE_MANAGER_WARNING_MSG =
-            "On Android 30 and above, request Manage All Files permission to read local files. " +
-            "A helper method MXRAndroidUtils.RequestManageAllFilesPermission() is provided in the SDK for the same. " +
+        const string EXTERNAL_READ_WARNING_MSG =
+            "On Android 30 and above, request Manage External Storage permission to read external files. " +
+            "MXRAndroidUtils.RequestManageAppAllFilesAccessPermission() is provided in the SDK for the same. " +
+            "On Android 29, use android:requestLegacyExternalStorage=\"true\" in your AndroidManifest.xml." +
             "Refer to the MXR Unity SDK README for more info.";
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -609,7 +609,7 @@ namespace MXR.SDK {
         bool CanAccessExternalFiles {
             get {
                 // If we're on level 29 and below, we don't need external storage manager permissions
-                if (!MXRAndroidUtils.NeedsManageAllFilesPermission)
+                if (!MXRAndroidUtils.NeedsManageExternalStoragePermission)
                     return true;
                 else
                     return MXRAndroidUtils.IsExternalStorageManager;

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -484,7 +484,7 @@ namespace MXR.SDK {
             // Method 1: Try to initialize using the external json file
             if (LoggingEnabled)
                 Debug.unityLogger.Log(TAG, "Checking if RuntimeSettingsSummary can be initialized using external json file.");
-            if (MXRAndroidUtils.CanAccessExternalFiles) {
+            if (CanAccessExternalFiles) {
                 filePath = _externalRuntimeSettingsSummaryFilePath;
 
                 if (InitFromFile(filePath)) {
@@ -540,7 +540,7 @@ namespace MXR.SDK {
             // Method 1: Try to initialize using the external json file
             if (LoggingEnabled)
                 Debug.unityLogger.Log(TAG, "Checking if DeviceStatus can be initialized using external json file.");
-            if (MXRAndroidUtils.CanAccessExternalFiles) {
+            if (CanAccessExternalFiles) {
                 filePath = _externalDeviceStatusPath;
 
                 if (InitFromFile(filePath)) {
@@ -601,6 +601,20 @@ namespace MXR.SDK {
             }
         }
         #endregion
+
+        /// <summary>
+        /// Returns whether the SDK can read external files, taking into account
+        /// whether we need any permissions for it or not.
+        /// </summary>
+        bool CanAccessExternalFiles {
+            get {
+                // If we're on level 29 and below, we don't need external storage manager permissions
+                if (!MXRAndroidUtils.NeedsManageAllFilesPermission)
+                    return true;
+                else
+                    return MXRAndroidUtils.IsExternalStorageManager;
+            }
+        }
 
         string EscapeStringToJsonString(string input) {
             // Escape JSON string. Ref: https://stackoverflow.com/a/26152046

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -425,8 +425,8 @@ namespace MXR.SDK {
 
         #region INITIALIZATION 
         void TryInitializeRuntimeSettingsSummary() {
-            // On Android30 and above, we check if we have storage access. Otherwise file read attempt will fail.
-            if(MXRAndroidUtils.AndroidSDKAsInt >= 30 && !MXRAndroidUtils.IsExternalStorageManager) {
+            // We check if we have storage access. Otherwise file read attempt will fail.
+            if(!CanAccessExternalFiles) {
                 if (LoggingEnabled)
                     Debug.unityLogger.LogWarning(TAG, "Not initializing RuntimeSettingsSummary using local json, " 
                     + "the SDK will fallback to trying to initialize it using the Android Messenger. This is not an error. "
@@ -449,8 +449,8 @@ namespace MXR.SDK {
         }
 
         void TryInitializeDeviceStatus() {
-            // On Android30 and above, we check if we have storage access. Otherwise file read attempt will fail.
-            if (MXRAndroidUtils.AndroidSDKAsInt >= 30 && !MXRAndroidUtils.IsExternalStorageManager) {
+            // We check if we have storage access. Otherwise file read attempt will fail.
+            if (!CanAccessExternalFiles) {
                 if (LoggingEnabled)
                     Debug.unityLogger.LogWarning(TAG, "Not initializing DeviceStatus using local json, "
                     + "the SDK will fallback to trying to initialize it using the Android Messenger. This is not an error. "
@@ -496,6 +496,20 @@ namespace MXR.SDK {
             output = output.Substring(1, output.Length - 2);
 
             return output;
+        }
+
+        bool CanAccessExternalFiles {
+            get {
+                // If we're on level 29 and below, we don't need external storage manager permissions
+                if (!MXRAndroidUtils.NeedsManageAllFilesPermission)
+                    return true;
+                else {
+                    if (MXRAndroidUtils.IsExternalStorageManager)
+                        return true;
+                    else
+                        return false;
+                }
+            }
         }
 
         const string EXTERNAL_STORAGE_MANAGER_WARNING_MSG =

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -40,16 +40,16 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Returns whether the SDK needs MANAGE_ALL_FILES permission for 
+        /// Returns whether the SDK needs MANAGE_EXTERNAL_STORAGE permission for 
         /// accessing files for proper functioning. This will return true
         /// if the device OS SDK level and the builds target SDK are both
         /// 29 and above which is where Scoped Storage for Android was introduced.
         /// </summary>
-        public static bool NeedsManageAllFilesPermission => 
+        public static bool NeedsManageExternalStoragePermission => 
             TargetSDKLevelAsInt >= 29 && AndroidSDKAsInt >= 29;
 
         /// <summary>
-        /// Returns whether the MANAGE_ALL_FILES permission has been granted
+        /// Returns whether the MANAGE_EXTERNAL_STORAGE permission has been granted
         /// for accessing files for proper functioning of the SDK.
         /// </summary>
         public static bool IsExternalStorageManager {
@@ -118,11 +118,12 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Opens Android system dialog for users to grant the MANAGE_ALL_FILES permission.
+        /// Opens Android system dialog for users to grant MANAGE_APP_ALL_FILES_ACCESS_PERMISSION.
         /// Note that if the AndroidManifest.xml of the Unity project doesn't have the 
-        /// MANAGE_ALL_FILES permission, the toggle button in the system dialog will be disabled.
+        /// MANAGE_EXTERNAL_STORAGE permission as described in the SDK README, 
+        /// the toggle button in the system dialog may be disabled.
         /// </summary>
-        public static void RequestManageAllFilesPermission() {
+        public static void RequestManageAppAllFilesAccessPermission() {
             try {
                 // Create an empty intent
                 AndroidJavaObject intent = new AndroidJavaObject("android.content.Intent");
@@ -144,5 +145,10 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Error, err);
             }
         }
+
+        [Obsolete("Use RequestManageAppAllFilesAccessPermission instead. " +
+        "This method may be removed in the future.")]
+        public static void RequestManageAllFilesPermission() =>
+            RequestManageAppAllFilesAccessPermission();
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -16,8 +16,51 @@ namespace MXR.SDK {
             return null;
         }
 
-        public static bool NeedsManageAllFilesPermission => AndroidSDKAsInt >= 30;
 
+        /// <summary>
+        /// Returns the SDK version of Android currently running on a device.
+        /// Ref: https://developer.android.com/reference/android/os/Build.VERSION#SDK_INT
+        /// </summary>
+        public static int AndroidSDKAsInt {
+            get {
+                AndroidJavaClass buildVersion = new AndroidJavaClass("android.os.Build$VERSION");
+                return buildVersion.GetStatic<int>("SDK_INT");
+            }
+        }
+
+        /// <summary>
+        /// Returns the SDK version the app is targeting.
+        /// </summary>
+        public static int TargetSDKLevelAsInt {
+            get {
+                return CurrentActivity
+                    .Call<AndroidJavaObject>("getApplicationContext")
+                    .Call<AndroidJavaObject>("getApplicationInfo")
+                    .Get<int>("targetSdkVersion");
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the SDK can read external files.
+        /// </summary>
+        public static bool CanAccessExternalFiles {
+            get {
+                // If we're on level 29 and below, we don't need external storage manager permissions
+                if (!NeedsManageAllFilesPermission)
+                    return true;
+                else
+                    return IsExternalStorageManager;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the SDK needs MANAGE_ALL_FILES permission for accessing files for proper functioning
+        /// </summary>
+        public static bool NeedsManageAllFilesPermission => TargetSDKLevelAsInt >= 29 && AndroidSDKAsInt >= 29;
+
+        /// <summary>
+        /// Returns whether the SDK has the isExternalStorageManager permission for accessing files for proper functioning.
+        /// </summary>
         public static bool IsExternalStorageManager {
             get {
                 AndroidJavaClass environment = new AndroidJavaClass("android.os.Environment");

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -16,6 +16,8 @@ namespace MXR.SDK {
             return null;
         }
 
+        public static bool NeedsManageAllFilesPermission => AndroidSDKAsInt >= 30;
+
         public static bool IsExternalStorageManager {
             get {
                 AndroidJavaClass environment = new AndroidJavaClass("android.os.Environment");

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -43,10 +43,10 @@ namespace MXR.SDK {
         /// Returns whether the SDK needs MANAGE_EXTERNAL_STORAGE permission for 
         /// accessing files for proper functioning. This will return true
         /// if the device OS SDK level and the builds target SDK are both
-        /// 29 and above which is where Scoped Storage for Android was introduced.
+        /// 30 and above which is where Scoped Storage for Android was introduced.
         /// </summary>
         public static bool NeedsManageExternalStoragePermission => 
-            TargetSDKLevelAsInt >= 29 && AndroidSDKAsInt >= 29;
+            TargetSDKLevelAsInt > 29 && AndroidSDKAsInt > 29;
 
         /// <summary>
         /// Returns whether the MANAGE_EXTERNAL_STORAGE permission has been granted

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -16,7 +16,6 @@ namespace MXR.SDK {
             return null;
         }
 
-
         /// <summary>
         /// Returns the SDK version of Android currently running on a device.
         /// Ref: https://developer.android.com/reference/android/os/Build.VERSION#SDK_INT
@@ -41,25 +40,17 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Returns whether the SDK can read external files.
+        /// Returns whether the SDK needs MANAGE_ALL_FILES permission for 
+        /// accessing files for proper functioning. This will return true
+        /// if the device OS SDK level and the builds target SDK are both
+        /// 29 and above which is where Scoped Storage for Android was introduced.
         /// </summary>
-        public static bool CanAccessExternalFiles {
-            get {
-                // If we're on level 29 and below, we don't need external storage manager permissions
-                if (!NeedsManageAllFilesPermission)
-                    return true;
-                else
-                    return IsExternalStorageManager;
-            }
-        }
+        public static bool NeedsManageAllFilesPermission => 
+            TargetSDKLevelAsInt >= 29 && AndroidSDKAsInt >= 29;
 
         /// <summary>
-        /// Returns whether the SDK needs MANAGE_ALL_FILES permission for accessing files for proper functioning
-        /// </summary>
-        public static bool NeedsManageAllFilesPermission => TargetSDKLevelAsInt >= 29 && AndroidSDKAsInt >= 29;
-
-        /// <summary>
-        /// Returns whether the SDK has the isExternalStorageManager permission for accessing files for proper functioning.
+        /// Returns whether the MANAGE_ALL_FILES permission has been granted
+        /// for accessing files for proper functioning of the SDK.
         /// </summary>
         public static bool IsExternalStorageManager {
             get {
@@ -127,7 +118,9 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Opens Android UI for users to grant the MANAGE_ALL_FILES permission
+        /// Opens Android system dialog for users to grant the MANAGE_ALL_FILES permission.
+        /// Note that if the AndroidManifest.xml of the Unity project doesn't have the 
+        /// MANAGE_ALL_FILES permission, the toggle button in the system dialog will be disabled.
         /// </summary>
         public static void RequestManageAllFilesPermission() {
             try {
@@ -147,7 +140,8 @@ namespace MXR.SDK {
 
             }
             catch (Exception e) {
-                Debug.unityLogger.Log(LogType.Error, "Failed to open MANAGE_ALL_FILES permission flow: " + e.Message);
+                string err = "Failed to open MANAGE_ALL_FILES permission system dialog: " + e.Message;
+                Debug.unityLogger.Log(LogType.Error, err);
             }
         }
     }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
@@ -8,17 +8,6 @@ namespace MXR.SDK {
         public static AndroidJavaClass AndroidOSBuild =>
             new AndroidJavaClass("android.os.Build");
 
-        /// <summary>
-        /// Returns the SDK version of Android currently running on a device.
-        /// Ref: https://developer.android.com/reference/android/os/Build.VERSION#SDK_INT
-        /// </summary>
-        public static int AndroidSDKAsInt {
-            get {
-                AndroidJavaClass buildVersion = new AndroidJavaClass("android.os.Build$VERSION");
-                return buildVersion.GetStatic<int>("SDK_INT");
-            }
-        }
-
         public static string DeviceManufacturer =>
             Application.isEditor ? "EDITOR" : AndroidOSBuild.GetStatic<string>("MANUFACTURER");
 

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.cs
@@ -12,16 +12,21 @@ namespace MXR.SDK {
             }
         }
 
+        static AndroidJavaObject applicationContext;
+        public static AndroidJavaObject ApplicationContext {
+            get {
+                if (applicationContext != null) return applicationContext;
+                applicationContext = CurrentActivity.Call<AndroidJavaObject>("applicationContext");
+                return applicationContext;
+            }
+        }
+
         static AndroidJavaObject plugin;
         public static AndroidJavaObject Plugin {
             get {
                 if (plugin != null) return plugin;
-                if (CurrentActivity != null) {
-                    var context = CurrentActivity?.Call<AndroidJavaObject>("getApplicationContext");
-                    plugin = new AndroidJavaObject("com.mightyimmersion.customlauncher.NativeUtils", context);
-                    return plugin;
-                }
-                return null;
+                plugin = new AndroidJavaObject("com.mightyimmersion.customlauncher.NativeUtils", ApplicationContext);
+                return plugin;
             }
         }
 


### PR DESCRIPTION
- On Android 30 and above, we check for Manage All Files permission before trying to read external json files. If permissions aren't available, we try cached/internal json files. If they don't exist, we skip json based init and wait for the messenger to receive the runtime settings summary and device status.