### PR TITLE
Correctly handle remote URL and local file locations in ImageDownloader

### DIFF
--- a/Assets/MXR.SDK/Samples/Scripts/ImageDownloader.cs
+++ b/Assets/MXR.SDK/Samples/Scripts/ImageDownloader.cs
@@ -9,7 +9,8 @@ namespace MXR.SDK.Samples {
     /// Loads an image from a remote URL or the local disk as a Texture2D object
     /// </summary>
     public class ImageDownloader {
-        [Obsolete("This method has been deprecated and may be removed soon, Instead construct an instance using \"new ImageDownloader();\"")]
+        [Obsolete("This method has been deprecated and may be removed soon. " +
+        "Instead of this method, construct an instance using \"new ImageDownloader();\"")]
         public static ImageDownloader New() {
             return new ImageDownloader();
         }
@@ -33,7 +34,7 @@ namespace MXR.SDK.Samples {
             // If the location is a URL, we use the remote download method
             if (location.Contains("http://") || location.Contains("https://"))
                 LoadFromURL(location, format, mipMap, onSuccess, onError);
-            // Otherwise we load it locally.
+            // Otherwise we load it from disk.
             else {
                 try {
                     var tex = LoadFromDisk(location, format, mipMap);

--- a/Assets/MXR.SDK/Samples/Scripts/LibraryPanel.cs
+++ b/Assets/MXR.SDK/Samples/Scripts/LibraryPanel.cs
@@ -81,6 +81,7 @@ namespace MXR.SDK.Samples {
                 .ForEach(x => {
                     var instance = Instantiate(webXRAppCellTemplate, cellContainer);
                     instance.gameObject.SetActive(true);
+                    instance.gameObject.name = x.title;
                     instance.webXRApp = x;
                     instance.Refresh();
                     webXRAppCells.Add(instance);
@@ -92,6 +93,7 @@ namespace MXR.SDK.Samples {
                 .ForEach(x => {
                     var instance = Instantiate(videoCellTemplate, cellContainer);
                     instance.gameObject.SetActive(true);
+                    instance.gameObject.name = x.title;
                     instance.video = x;
                     instance.status = MXRManager.System.DeviceStatus.FileInstallStatusForVideo(x);
                     instance.Refresh();
@@ -104,6 +106,7 @@ namespace MXR.SDK.Samples {
                 .ForEach(x => {
                     var instance = Instantiate(appCellTemplate, cellContainer);
                     instance.gameObject.SetActive(true);
+                    instance.gameObject.name = x.title;
                     instance.runtimeApp = x;
                     instance.status = MXRManager.System.DeviceStatus.AppInstallStatusForRuntimeApp(x);
                     instance.Refresh();

--- a/Assets/MXR.SDK/Samples/Scripts/RuntimeAppCell.cs
+++ b/Assets/MXR.SDK/Samples/Scripts/RuntimeAppCell.cs
@@ -20,20 +20,22 @@ namespace MXR.SDK.Samples {
         public void Refresh() {
             title.text = runtimeApp.title;
 
-            // Instead of MXRStorage.GetFullPath(video.iconPath) you can also use
-            // video.iconUrl to download the icon from a server.
-            ImageDownloader.New().Download(MXRStorage.GetFullPath(runtimeApp.iconPath),
-                x => {
+            // Instead of MXRStorage.GetFullPath(runtimeApp.iconPath) you can also use
+            // runtimeApp.iconUrl to download the icon from a URL, like this:
+            //new ImageDownloader().Load(runtimeApp.iconUrl, TextureFormat.ARGB32, true, result =>{}, error =>{});
+            new ImageDownloader().Load(MXRStorage.GetFullPath(runtimeApp.iconPath), TextureFormat.ARGB32, true,
+                result => {
                     if (isBeingDestroyed) return;
 
-                    if (x == null) {
+                    if (result == null) {
                         icon.sprite = defaultIcon;
                         return;
                     }
 
-                    icon.sprite = Sprite.Create(x, new Rect(0, 0, x.width, x.height), Vector2.one / 2);
+                    icon.sprite = Sprite.Create(result, new Rect(0, 0, result.width, result.height), Vector2.one / 2);
                     icon.preserveAspect = true;
-                }
+                },
+                error => icon.sprite = defaultIcon
             );
 
             SetRequirementIcon(controllerRequirement, runtimeApp.controllersRequired);

--- a/Assets/MXR.SDK/Samples/Scripts/VideoCell.cs
+++ b/Assets/MXR.SDK/Samples/Scripts/VideoCell.cs
@@ -18,24 +18,26 @@ namespace MXR.SDK.Samples {
         public void Refresh() {
             title.text = video.title;
 
-            SetRequirementIcon(controllerRequirement, video.controllersRequired);
-            SetRequirementIcon(internetRequirement, video.internetRequired);
-
             // Instead of MXRStorage.GetFullPath(video.iconPath) you can also use
-            // video.iconUrl to download the icon from a server.
-            ImageDownloader.New().Download(MXRStorage.GetFullPath(video.iconPath),
-                x => {
+            // video.iconUrl to download the icon from a URL, like this:
+            //new ImageDownloader().Load(video.iconUrl, TextureFormat.ARGB32, true, result =>{}, error =>{});
+            new ImageDownloader().Load(MXRStorage.GetFullPath(video.iconPath), TextureFormat.ARGB32, true,
+                result => {
                     if (isBeingDestroyed) return;
 
-                    if (x == null) {
+                    if (result == null) {
                         icon.sprite = defaultIcon;
                         return;
                     }
 
-                    icon.sprite = Sprite.Create(x, new Rect(0, 0, x.width, x.height), Vector2.one / 2);
+                    icon.sprite = Sprite.Create(result, new Rect(0, 0, result.width, result.height), Vector2.one / 2);
                     icon.preserveAspect = true;
-                }
+                },
+                error => icon.sprite = defaultIcon
             );
+
+            SetRequirementIcon(controllerRequirement, video.controllersRequired);
+            SetRequirementIcon(internetRequirement, video.internetRequired);
 
             if (status != null) {
                 if (status.status == FileInstallStatus.Status.COMPLETE) {

--- a/Assets/MXR.SDK/Samples/Scripts/WebXRAppCell.cs
+++ b/Assets/MXR.SDK/Samples/Scripts/WebXRAppCell.cs
@@ -14,24 +14,27 @@ namespace MXR.SDK.Samples {
         public void Refresh() {
             title.text = webXRApp.title;
 
-            SetRequirementIcon(controllerRequirement, webXRApp.controllersRequired);
-            SetRequirementIcon(internetRequirement, webXRApp.internetRequired);
+            // Instead of MXRStorage.GetFullPath(webXRApp.iconPath) you can also use
+            // webXRApp.iconUrl to download the icon from a URL, like this:
+            //new ImageDownloader().Load(webXRApp.iconUrl, TextureFormat.ARGB32, true, result =>{}, error =>{});
 
-            // Instead of MXRStorage.GetFullPath(video.iconPath) you can also use
-            // video.iconUrl to download the icon from a server.
-            ImageDownloader.New().Download(MXRStorage.GetFullPath(webXRApp.iconPath),
-                x => {
+            new ImageDownloader().Load(MXRStorage.GetFullPath(webXRApp.iconPath), TextureFormat.ARGB32, true,
+                result => {
                     if (isBeingDestroyed) return;
 
-                    if (x == null) {
+                    if (result == null) {
                         icon.sprite = defaultIcon;
                         return;
                     }
 
-                    icon.sprite = Sprite.Create(x, new Rect(0, 0, x.width, x.height), Vector2.one / 2);
+                    icon.sprite = Sprite.Create(result, new Rect(0, 0, result.width, result.height), Vector2.one / 2);
                     icon.preserveAspect = true;
-                }
+                },
+                error => icon.sprite = defaultIcon
             );
+
+            SetRequirementIcon(controllerRequirement, webXRApp.controllersRequired);
+            SetRequirementIcon(internetRequirement, webXRApp.internetRequired);
         }
 
         void SetRequirementIcon(Image icon, Content.Requirement requirement) {


### PR DESCRIPTION
`ImageDownloader` is a utility in our Samples, used for the Library sample specifically. However it's often a starting point for customer integration. 

Previously some locally stored images were not loading correctly due to not being able to "resolve host" because we used Unity's `WWW` class for them which is actually meant for web requests and is also obsolete. 

Instead we now use .NET's `WebClient` class for remote (URL) images and .NET's `File` class for local ones.

- ImageDownloader offers separate methods to load images from URL and disk, along with a general purpose Load method.
- ImageDownloader is no longer MonoBehaviour based.
- Old methods in ImageDownloader deprecated with warning but remain compatible with the new download logic.
- Files.zip updated with new icon files for testing Library sample scene in editor.