### PR TITLE
Fix issue where SDK hangs during service binding with the Home Screen

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -221,7 +221,7 @@ public class AdminAppMessengerManager {
         List<PackageInfo> packages = pm.getInstalledPackages(0);
 
         for (PackageInfo packageInfo : packages) {
-            if (packageInfo.packageName.startsWith("com.mightyimmersion.mightyplatform.adminapp") && !packageInfo.packageName.contains("preload")) {
+            if (packageInfo.packageName.startsWith("com.mightyimmersion.mightyplatform.adminapp") && !packageInfo.packageName.contains("preload") && !packageInfo.packageName.contains("test")) {
                 return new ComponentName(packageInfo.packageName, ADMIN_SERVICE_CLASS_NAME);
             }
         }

--- a/Assets/MXR.SDK/Runtime/MXRManager.cs
+++ b/Assets/MXR.SDK/Runtime/MXRManager.cs
@@ -67,8 +67,7 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Log, TAG, "Waiting for MXRManager.System to be available.");
 
             // We keep waiting for 100 milliseconds until the system is available.
-            while (!System.IsConnectedToAdminApp)
-            {
+            while (!System.IsConnectedToAdminApp) {
                 Debug.unityLogger.Log("Waiting to connect to Admin App")
                 await Task.Delay(100);
             }
@@ -80,8 +79,10 @@ namespace MXR.SDK {
             if (System.RuntimeSettingsSummary == null)
                 Debug.unityLogger.Log(LogType.Log, TAG, "Waiting for MXRManager.System.RuntimeSettingsSummary to be initialized.");
 
-            while (System.DeviceStatus == null || System.RuntimeSettingsSummary == null)
+            while (System.DeviceStatus == null || System.RuntimeSettingsSummary == null) {
+                Debug.unityLogger.Log("Waiting for DeviceStatus and RuntimeSettingsSummary")
                 await Task.Delay(100);
+            }
 
             Debug.unityLogger.Log(LogType.Log, TAG, "MXRManager finished initializing.");
             return result;

--- a/Assets/MXR.SDK/Runtime/MXRManager.cs
+++ b/Assets/MXR.SDK/Runtime/MXRManager.cs
@@ -68,7 +68,10 @@ namespace MXR.SDK {
 
             // We keep waiting for 100 milliseconds until the system is available.
             while (!System.IsConnectedToAdminApp)
+            {
+                Debug.unityLogger.Log("Waiting to connect to Admin App")
                 await Task.Delay(100);
+            }
 
             // Next we wait for the DeviceStatus and RuntimeSettingsSummary to become non null.
             if (System.DeviceStatus == null)

--- a/Assets/MXR.SDK/Runtime/MXRManager.cs
+++ b/Assets/MXR.SDK/Runtime/MXRManager.cs
@@ -68,7 +68,7 @@ namespace MXR.SDK {
 
             // We keep waiting for 100 milliseconds until the system is available.
             while (!System.IsConnectedToAdminApp) {
-                Debug.unityLogger.Log("Waiting to connect to Admin App")
+                Debug.unityLogger.Log("Waiting to connect to Admin App");
                 await Task.Delay(100);
             }
 
@@ -80,7 +80,7 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Log, TAG, "Waiting for MXRManager.System.RuntimeSettingsSummary to be initialized.");
 
             while (System.DeviceStatus == null || System.RuntimeSettingsSummary == null) {
-                Debug.unityLogger.Log("Waiting for DeviceStatus and RuntimeSettingsSummary")
+                Debug.unityLogger.Log("Waiting for DeviceStatus and RuntimeSettingsSummary");
                 await Task.Delay(100);
             }
 


### PR DESCRIPTION
Fixed issue where the SDK AdminAppMessengerManager would fail to bind the Admin App and Home screen, due to a rare case in which the package name "com.mightyimmersion.mightyplatform.adminapp.test" was being returned from a search prior to "com.mightyimmersion.mightyplatform.adminapp"

Added logging for the following cases
- While waiting to connect to Admin App
- While waiting for  DeviceStatus and RuntimeSettingsSummary"
