### PR TITLE
Added disableGazeInput in RuntimeSettingsSummary

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -101,6 +101,12 @@ namespace MXR.SDK {
         public bool forceAndroid12PermissionsAccept = false;
 
         /// <summary>
+        /// Disables gaze input mode when no controllers or handtracking is available. 
+        /// Instead, the headset button will be used to trigger clicks.
+        /// </summary>
+        public bool disableGazeInput = false;
+
+        /// <summary>
         /// Helper property for whether the guardian settings are hidden
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
We no longer use featureFlags, this is being made into an SDK level feature.