### PR TITLE
JNI improvements

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
+++ b/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
@@ -32,12 +32,9 @@ namespace MXR.SDK {
         /// Creates an instance of the messenger manager
         /// </summary>
         public AdminAppMessengerManager() {
-            AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-            AndroidJavaObject activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
-            AndroidJavaObject context = activity.Call<AndroidJavaObject>("getApplicationContext");
             native = new AndroidJavaObject(
                 "com.mightyimmersion.customlauncher.AdminAppMessengerManager", 
-                context, 
+                MXRAndroidUtils.ApplicationContext, 
                 new AdminAppMessengerListener(this)
             );
             Debug.unityLogger.Log(LogType.Log, "AdminAppMessengerManager JNI bridge created.");
@@ -51,17 +48,15 @@ namespace MXR.SDK {
         /// </summary>
         /// <typeparam name="T">The return type of the method</typeparam>
         /// <param name="methodName">The name of the method invoked</param>
-        public T Call<T>(string methodName) {
-            return native.Call<T>(methodName);
-        }
+        public T Call<T>(string methodName) =>
+            native.SafeCall<T>(methodName);
 
         /// <summary>
         /// Invokes a method in <see cref="native"/> using method name
         /// </summary>
         /// <param name="methodName">The name of the method invoked</param>
-        public void Call(string methodName) {
-            native.Call(methodName);
-        }
+        public void Call(string methodName) =>
+            native.SafeCall(methodName);
 
         /// <summary>
         /// Invokes a method in <see cref="native"/> using name and arguments
@@ -71,18 +66,16 @@ namespace MXR.SDK {
         /// <param name="methodName">The name of the method invoked</param>
         /// <param name="args">The arguments passed to the method</param>
         /// <returns></returns>
-        public T Call<T>(string methodName, params object[] args) {
-            return native.Call<T>(methodName, args);
-        }
+        public T Call<T>(string methodName, params object[] args) =>
+            native.SafeCall<T>(methodName, args);
 
         /// <summary>
         /// Invokes a method in <see cref="native"/> using name and arguments
         /// </summary>
         /// <param name="methodName">The name of the method invoked</param>
         /// <param name="args">The arguments passed to the method</param>
-        public void Call(string methodName, params object[] args) {
-            native.Call(methodName, args);
-        }
+        public void Call(string methodName, params object[] args) =>
+            native.SafeCall(methodName, args);
 
         /// <summary>
         /// Sends a message to the Admin App through messenger.
@@ -90,9 +83,8 @@ namespace MXR.SDK {
         /// </summary>
         /// <param name="messageType">The type/ID of the message</param>
         /// <returns>Whether the message was sent. This will be false if the messenger wasn't bound to service</returns>
-        public bool SendMessageToAdminApp(int messageType) {
-            return Call<bool>("sendMessage", messageType);
-        }
+        public bool SendMessageToAdminApp(int messageType) =>
+            native.SafeCall<bool>("sendMessage", messageType);
 
         /// <summary>
         /// Sends a message to the Admin App through the messenger.
@@ -101,9 +93,8 @@ namespace MXR.SDK {
         /// <param name="messageType">The type/ID of the message</param>
         /// <param name="dataJson">Payload associated with the message as a json string</param>
         /// <returns>Whether the message was sent. This will be false if the messenger wasn't bound to service</returns>
-        public bool SendMessageToAdminApp(int messageType, string dataJson) {
-            return Call<bool>("sendMessage", messageType, dataJson);
-        }
+        public bool SendMessageToAdminApp(int messageType, string dataJson) =>
+            native.SafeCall<bool>("sendMessage", messageType, dataJson);
 
         /// <summary>
         /// Class that implements the AdminAppMessengerListener native interface

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -41,11 +41,8 @@ namespace MXR.SDK {
             set => loggingEnabled = value;
         }
 
-        public bool IsAdminAppInstalled {
-            get {
-                return MXRAndroidUtils.NativeUtils.Call<bool>("isAdminAppInstalled");
-            }
-        }
+        public bool IsAdminAppInstalled =>
+            MXRAndroidUtils.NativeUtils.SafeCall<bool>("isAdminAppInstalled");
 
         public bool IsConnectedToAdminApp => IsAvailable;
         public bool IsAvailable => messenger.IsBoundToService;

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Bluetooth.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Bluetooth.cs
@@ -7,7 +7,7 @@ namespace MXR.SDK {
         /// </summary>
         public static void LaunchBluetoothSettings() {
             var action = "android.settings.BLUETOOTH_SETTINGS";
-            NativeUtils.Call<bool>("launchIntentAction", action);
+            NativeUtils.SafeCall<bool>("launchIntentAction", action);
         }
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
@@ -5,30 +5,57 @@ using UnityEngine;
 
 namespace MXR.SDK {
     public static partial class MXRAndroidUtils {
-        public static AndroidJavaClass AndroidOSBuild =>
-            new AndroidJavaClass("android.os.Build");
+        /// <summary>
+        /// JNI to get a class instance of android.os.Build
+        /// </summary>
+        public static AndroidJavaClass AndroidOSBuild {
+            get {
+                if (androidOSBuild == null)
+                    androidOSBuild = new AndroidJavaClass("android.os.Build");
+                return androidOSBuild;
+            }
+        }
+        static AndroidJavaClass androidOSBuild;
 
         // HARDWARE STRINGS
         /// <summary>
         /// The manufacturer string of current device. Equivalent to android.os.Build.MANUFACTURER
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
-        public static string DeviceManufacturer =>
-            Application.isEditor ? "EDITOR" : AndroidOSBuild.GetStatic<string>("MANUFACTURER");
+        public static string DeviceManufacturer {
+            get {
+                if(deviceManufacturer == null) 
+                    deviceManufacturer = Application.isEditor ? "EDITOR" : AndroidOSBuild.SafeGetStatic<string>("MANUFACTURER");
+                return deviceManufacturer;
+            }
+        }
+        static string deviceManufacturer;
 
         /// <summary>
         /// The manufacturer string of current device. Equivalent to android.os.Build.MODEL
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
-        public static string DeviceModel =>
-            Application.isEditor ? "EDITOR" : AndroidOSBuild.GetStatic<string>("MODEL");
+        public static string DeviceModel {
+            get {
+                if(deviceModel == null)
+                    deviceModel = Application.isEditor ? "EDITOR" : AndroidOSBuild.SafeGetStatic<string>("MODEL");
+                return deviceModel;
+            }
+        }
+        static string deviceModel;
 
         /// <summary>
         /// The manufacturer string of current device. Equivalent to android.os.Build.PRODUCT
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
-        public static string DeviceProduct =>
-            Application.isEditor ? "EDITOR" : AndroidOSBuild.GetStatic<string>("PRODUCT");
+        public static string DeviceProduct {
+            get {
+                if(deviceProduct == null)
+                    deviceProduct = Application.isEditor ? "EDITOR" : AndroidOSBuild.SafeGetStatic<string>("PRODUCT");
+                return deviceProduct;
+            }
+        }
+        static string deviceProduct;
 
         // MANUFACTURER DETECTION
         /// <summary>
@@ -181,12 +208,6 @@ namespace MXR.SDK {
             IsPicoG2 || IsPicoG3;
 
         /// <summary>
-        /// Returns whether the SDK is running on a device with 3DoF headset
-        /// </summary>
-        [Obsolete("Use IsHeadset3DOF instead. This proparty may be removed in the future.")]
-        public static bool Is3DOF => IsHeadset3DOF;
-
-        /// <summary>
         /// Returns whether the SDK is running on a Pico device with 6DoF headset tracking
         /// </summary>
         public static bool IsPico6DOF => IsPicoDevice && IsHeadset6DOF;
@@ -201,12 +222,18 @@ namespace MXR.SDK {
         /// Returns Pico's UI version. returns "0.0.0" if current device is not a Pico device
         /// </summary>
         public static string PicoUIVersion =>
-            IsPicoDevice ? AndroidOSBuild.GetStatic<string>("DISPLAY") : "0.0.0";
+            IsPicoDevice ? AndroidOSBuild.SafeGetStatic<string>("DISPLAY") : "0.0.0";
 
         /// <summary>
         /// Returns if current Pico UI version is 4.x.x if current device is a Pico device
         /// </summary>
         public static bool IsPicoUI4 =>
             PicoUIVersion.StartsWith("4");
+
+        /// <summary>
+        /// Returns whether the SDK is running on a device with 3DoF headset
+        /// </summary>
+        [Obsolete("Use IsHeadset3DOF instead. This proparty may be removed in the future.")]
+        public static bool Is3DOF => IsHeadset3DOF;
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.cs
@@ -73,6 +73,7 @@ namespace MXR.SDK {
         public static bool HasIntentExtra(string key) {
             var intent = CurrentActivity.SafeCall<AndroidJavaObject>("getIntent");
             var bundle = intent.SafeCall<AndroidJavaObject>("getExtras");
+            if(bundle == null) return false;
             return bundle.SafeCall<bool>("containsKey", key);
         }
 

--- a/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs
@@ -12,7 +12,7 @@ namespace MXR.SDK {
         const string TAG = "SafeJNI";
 
         /// <summary>
-        /// Calls a void-returning static method on a native object using method name and optional arguments. 
+        /// Calls a static void method on a native object using method name with optional arguments.
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="methodName"></param>
@@ -42,13 +42,13 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Calls a value-returning static method on a native object using method name and optional arguments. 
+        /// Calls a static method on a native object using method name with optional arguments, and returns the result.
         /// </summary>
         /// <typeparam name="ReturnType">The type as which the result should be returned.</typeparam>
         /// <param name="obj"></param>
         /// <param name="methodName"></param>
         /// <param name="args"></param>
-        /// <returns>Success: The field value. Failure: Default type value.</returns>
+        /// <returns>Success: The JNI result. Failure: Default type value.</returns>
         public static ReturnType SafeCallStatic<ReturnType>(this AndroidJavaObject obj, string methodName, params object[] args) {
             if (obj == null) {
                 Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to call " + methodName + " on a null AndroidJavaObject");
@@ -72,7 +72,7 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Calls a void-returning non-static method on a native object using method name and optional arguments.
+        /// Calls a void method on a native object using method name with optional arguments.
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="methodName"></param>
@@ -102,7 +102,7 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Calls a value-returning non-static method on a native object using method name and optional parameters.
+        /// Calls a method on a native object using method name with optional parameters, and returns the result.
         /// </summary>
         /// <typeparam name="ReturnType">The type as which the result should be returned.</typeparam>
         /// <param name="obj"></param>
@@ -158,7 +158,7 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Gets a non-static field of a native object.
+        /// Gets a field of a native object.
         /// </summary>
         /// <typeparam name="ReturnType">The type as which the field should be retrieved.</typeparam>
         /// <param name="obj"></param>

--- a/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs
@@ -1,0 +1,186 @@
+﻿using System;
+
+using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// This utility class provides extension methods for invoking JNI methods while logging any errors that occur.
+    /// The occurring exception is consumed and not propagated up, this is intentional as our general usage of JNI 
+    /// in Unity C# is to only check if a call succeeded or not, and not really handle exceptions.
+    /// </summary>
+    public static class SafeJNI {
+        const string TAG = "SafeJNI";
+
+        /// <summary>
+        /// Calls a void-returning static method on a native object using method name and optional arguments. 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="methodName"></param>
+        /// <param name="args"></param>
+        /// <returns>Success: true. Failure: false</returns>
+        public static bool SafeCallStatic(this AndroidJavaObject obj, string methodName, params object[] args) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to call " + methodName + " on a null AndroidJavaObject");
+                return false;
+            }
+
+            try {
+                if (args == null || args.Length == 0)
+                    obj.CallStatic(methodName);
+                else
+                    obj.CallStatic(methodName, args);
+                return true;
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return false;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Calls a value-returning static method on a native object using method name and optional arguments. 
+        /// </summary>
+        /// <typeparam name="ReturnType">The type as which the result should be returned.</typeparam>
+        /// <param name="obj"></param>
+        /// <param name="methodName"></param>
+        /// <param name="args"></param>
+        /// <returns>Success: The field value. Failure: Default type value.</returns>
+        public static ReturnType SafeCallStatic<ReturnType>(this AndroidJavaObject obj, string methodName, params object[] args) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to call " + methodName + " on a null AndroidJavaObject");
+                return default;
+            }
+
+            try {
+                if (args == null || args.Length == 0)
+                    return obj.CallStatic<ReturnType>(methodName);
+                else
+                    return obj.CallStatic<ReturnType>(methodName, args);
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return default;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Calls a void-returning non-static method on a native object using method name and optional arguments.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="methodName"></param>
+        /// <param name="args"></param>
+        /// <returns>Success: true. Failure: false</returns>
+        public static bool SafeCall(this AndroidJavaObject obj, string methodName, params object[] args) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to call " + methodName + " on a null AndroidJavaObject");
+                return false;
+            }
+
+            try {
+                if (args == null || args.Length == 0)
+                    obj.Call(methodName);
+                else
+                    obj.Call(methodName, args);
+                return true;
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return false;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Calls a value-returning non-static method on a native object using method name and optional parameters.
+        /// </summary>
+        /// <typeparam name="ReturnType">The type as which the result should be returned.</typeparam>
+        /// <param name="obj"></param>
+        /// <param name="methodName"></param>
+        /// <param name="args"></param>
+        /// <returns>Success: The field value. Failure: Default type value.</returns>
+        public static ReturnType SafeCall<ReturnType>(this AndroidJavaObject obj, string methodName, params object[] args) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to call " + methodName + " on a null AndroidJavaObject");
+                return default;
+            }
+
+            try {
+                if (args == null || args.Length == 0)
+                    return obj.Call<ReturnType>(methodName);
+                else
+                    return obj.Call<ReturnType>(methodName, args);
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return default;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Gets a static field of a native object.
+        /// </summary>
+        /// <typeparam name="ReturnType">The type as which the field should be retrieved.</typeparam>
+        /// <param name="obj"></param>
+        /// <param name="fieldName"></param>
+        /// <returns>Success: The field value. Failure: Default type value.</returns>
+        public static ReturnType SafeGetStatic<ReturnType>(this AndroidJavaObject obj, string fieldName) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to get field " + fieldName + " from a null AndroidJavaObject");
+                return default;
+            }
+
+            try {
+                return obj.GetStatic<ReturnType>(fieldName);
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return default;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Gets a non-static field of a native object.
+        /// </summary>
+        /// <typeparam name="ReturnType">The type as which the field should be retrieved.</typeparam>
+        /// <param name="obj"></param>
+        /// <param name="fieldName"></param>
+        /// <returns>Success: The field value. Failure: Default type value.</returns>
+        public static ReturnType SafeGet<ReturnType>(this AndroidJavaObject obj, string fieldName) {
+            if (obj == null) {
+                Debug.unityLogger.Log(LogType.Error, TAG, "JNI Error: Tried to get field " + fieldName + " from a null AndroidJavaObject");
+                return default;
+            }
+
+            try {
+                return obj.Get<ReturnType>(fieldName);
+            }
+            catch (AndroidJavaException e) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "JNI Exception: " + e);
+                return default;
+            }
+            catch (Exception ex) {
+                Debug.unityLogger.Log(LogType.Exception, TAG, "Unexpected Exception: " + ex);
+                return default;
+            }
+        }
+    }
+}

--- a/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs.meta
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/SafeJNI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9625d693ad6e8934390150a8031ec0b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/Runtime/Utils/MXRStorage.cs
+++ b/Assets/MXR.SDK/Runtime/Utils/MXRStorage.cs
@@ -16,8 +16,8 @@ namespace MXR.SDK {
                     return Application.dataPath.Replace("Assets", "Files");
                 else {
                     var path = new AndroidJavaClass("android.os.Environment")
-                        .CallStatic<AndroidJavaObject>("getExternalStorageDirectory")
-                        .Call<string>("getPath");
+                        .SafeCallStatic<AndroidJavaObject>("getExternalStorageDirectory")
+                        .SafeCall<string>("getPath");
                     EnsurePath(path);
                     return path;
                 }

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.36f1
-m_EditorVersionWithRevision: 2019.4.36f1 (660c164b2fc5)
+m_EditorVersion: 2019.4.40f1
+m_EditorVersionWithRevision: 2019.4.40f1 (ffc62b691db5)


### PR DESCRIPTION
* SafeJNI class introduced to offer try/catch wrapped JNI calls

This allows us to log JNI exceptions without stopping executing for code. Example:

```
void GetSomething(AndroidJavaObject obj){
    var flag = obj.SafeGet<AndroidJavaObject>("getInternalObject"); // Prints exception if error occurs
    Debug.Log("Success " + flag != default); // Works even if the above call fails
}
```

The general idea is that in JNI we don't really care about exceptions, the errors just get logged and we only check if the call was successful. But if it isn't, code execution stops.

Future improvements such as specifying default value on failure can be added if we need them.

* Caching of JNI values where they don't change:
- AndroidSDKAsInt
- TargetSDKLevelAsInt
- DeviceManufacturer
- DeviceModel
- DeviceProduct
* Better caching of AndroidJavaObject instances, and ensuring we used cached properties internally