### PR TITLE
Fix MXRAndroidUtils.GetInstalledPackageVersionName

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -66,7 +66,7 @@ namespace MXR.SDK {
 
         public static string GetInstalledPackageVersionName(string packageName) {
             if (NativeUtils != null)
-                NativeUtils.SafeCall<string>("getInstalledPackagedVersionName", packageName);
+                return NativeUtils.SafeCall<string>("getInstalledPackagedVersionName", packageName);
             return null;
         }
 


### PR DESCRIPTION
During the update to `SafeJNI` class, we stopped returning the value from this method properly