### PR TITLE
chore[logs]: Editor System fixing disable wifi log

### DIFF
--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -214,7 +214,7 @@ namespace MXR.SDK {
                 WifiConnectionStatus.wifiIsEnabled = false;
                 WriteWifiConnectionStatus();
                 if (LoggingEnabled)
-                    Debug.unityLogger.Log(LogType.Log, TAG, "Disabled Kiosk Mode");
+                    Debug.unityLogger.Log(LogType.Log, TAG, "Disabled Wifi");
             }
             catch(Exception e) {
                 if (LoggingEnabled)


### PR DESCRIPTION
The Disable Wifi action was previous logging as 'Disabled Kiosk Mode', so this has been corrected. 