### PR TITLE
Added types for card customization

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -208,6 +208,8 @@ namespace MXR.SDK {
         /// </summary>
         public HiddenSettings hiddenSettings = new HiddenSettings();
 
+        public LibrarySettings librarySettings = new LibrarySettings();
+
         /// <summary>
         /// Whether the guardian/boundary settings should be opened on launch
         /// </summary>
@@ -275,6 +277,17 @@ namespace MXR.SDK {
         public bool wifi;
         public bool passthrough;
         public bool brightness;
+    }
+
+    [Serializable]
+    public class LibrarySettings {
+        public CardSettings cardSettings = new CardSettings();
+    }
+
+    [Serializable]
+    public class CardSettings {
+        public bool showTitle = true;
+        public bool showContentType = true;
     }
 
     /// <summary>

--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -195,7 +195,6 @@ namespace MXR.SDK {
         /// </summary>
         public DisplayLanguage displayLanguage = DisplayLanguage.enUS;
 
-
         /// <summary>
         /// Whether the shortcut menu should NOT be shown when the user comes back to the
         /// homescreen app when <see cref="RuntimeSettingsSummary.deviceExperienceMode"/>
@@ -208,6 +207,9 @@ namespace MXR.SDK {
         /// </summary>
         public HiddenSettings hiddenSettings = new HiddenSettings();
 
+        /// <summary>
+        /// Customization settings for the library panel
+        /// </summary>
         public LibrarySettings librarySettings = new LibrarySettings();
 
         /// <summary>
@@ -279,15 +281,31 @@ namespace MXR.SDK {
         public bool brightness;
     }
 
+    /// <summary>
+    /// Customization settings for the library panel
+    /// </summary>
     [Serializable]
     public class LibrarySettings {
+        /// <summary>
+        /// Customization settings for the content cards shows in the library panel
+        /// </summary>
         public CardSettings cardSettings = new CardSettings();
     }
 
+    /// <summary>
+    /// Customization settings for the content cards shows in the library panel
+    /// </summary>
     [Serializable]
     public class CardSettings {
-        public bool showTitle = true;
-        public bool showContentType = true;
+        /// <summary>
+        /// Whether the content cards should show the title text
+        /// </summary>
+        public bool showTitle;
+
+        /// <summary>
+        /// Whether the content cards should show the content type text ("App", "Video", WebXR")
+        /// </summary>
+        public bool showContentType;
     }
 
     /// <summary>


### PR DESCRIPTION
New types introduced for library card customization:
* `public class CardSettings`
  - `public bool showTitle`
  - `public bool showContentType`
* `public class LibrarySettings`
  - `public CardSettings cardSettings`

Object `public LibrarySettings librarySettings` added to `CustomLauncherSettings` class

Access via:
* `RuntimeSettingsSummary.customLauncher.librarySettings.cardSettings.showTitle`
* `RuntimeSettingsSummary.customLauncher.librarySettings.cardSettings.showContentType`