### PR TITLE
Added GridSettings.verticalAlignment and horizontalAlignment

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -312,14 +312,23 @@ namespace MXR.SDK {
         /// </summary>
         public int cardsPerRow = 4;
 
+        public VerticalCardAlignment verticalAlignment = VerticalCardAlignment.TOP;
+
         /// <summary>
         /// The alignment of the cards in the library content card grid
         /// </summary>
-        public CardAlignment alignment = CardAlignment.LEFT;
+        public HorizontalCardAlignment horizontalAlignment = HorizontalCardAlignment.LEFT;
     }
 
     [Serializable]
-    public enum CardAlignment {
+    public enum VerticalCardAlignment {
+        TOP,
+        CENTER,
+        BOTTOM
+    }
+
+    [Serializable]
+    public enum HorizontalCardAlignment {
         LEFT,
         CENTER,
         RIGHT


### PR DESCRIPTION
* `alignment` field was previously used for horizontal alignment. It has been renamed to `horizontalAlignment` and `verticalAlignment` has been added