### PR TITLE
Introduced MXRPicoUtils for Pico specific utilities

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -89,8 +89,9 @@ namespace MXR.SDK {
         public static void LaunchAppWithPackageAndClassNames(string packageName, string className) =>
             NativeUtils.SafeCall<bool>("launchAppWithClass", packageName, className);
 
-        public static void LaunchAppWithIntentAction(string intentAction) =>
+        public static void LaunchIntentAction(string intentAction) =>
             NativeUtils.SafeCall<bool>("launchIntentAction", intentAction);
+
 
         public static string GetAdminAppPackageName() =>
             NativeUtils.SafeCall<string>("getInstalledAdminAppPackageName");
@@ -101,9 +102,13 @@ namespace MXR.SDK {
             return -1;
         }
 
-        public static string GetProductName() {
+        /// <summary>
+        /// Returns a system property using the android.os.SystemProperties.get method
+        /// </summary>
+        /// <param name="property">The property to fetch</param>
+        public static string GetSystemProperty(string property) {
             if (NativeUtils != null)
-                return NativeUtils.SafeCall<string>("getSystemProperty", "ro.product.name");
+                return NativeUtils.SafeCall<string>("getSystemProperty", property);
             return "";
         }
 
@@ -137,6 +142,7 @@ namespace MXR.SDK {
             }
         }
 
+        #region OBSOLETE
         [Obsolete("Use RequestManageAppAllFilesAccessPermission instead. " +
         "This method may be removed in the future.")]
         public static void RequestManageAllFilesPermission() =>
@@ -153,5 +159,15 @@ namespace MXR.SDK {
             if (NativeUtils?.SafeCall("killApp", packageName) == false)
                 Debug.unityLogger.Log(LogType.Error, "Could not kill app " + packageName);
         }
+
+        [Obsolete("Use GetSystemProperty(\"r.product.name\") instead")]
+        public static string GetProductName() =>
+            GetSystemProperty("ro.product.name");
+
+
+        [Obsolete("Use LaunchIntentAction instead.")]
+        public static void LaunchAppWithIntentAction(string intentAction) =>
+            LaunchIntentAction(intentAction);
+        #endregion
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
@@ -32,7 +32,7 @@ namespace MXR.SDK {
         static string deviceManufacturer;
 
         /// <summary>
-        /// The manufacturer string of current device. Equivalent to android.os.Build.MODEL
+        /// The model string of current device. Equivalent to android.os.Build.MODEL
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
         public static string DeviceModel {
@@ -45,22 +45,21 @@ namespace MXR.SDK {
         static string deviceModel;
 
         /// <summary>
-        /// The manufacturer string of current device. system property ro.product.name
+        /// The ro.product.name string of current device reported by android.os.SystemProperties
+        /// Equivalent to android.os.SystemProperties("ro.product.name")
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
         public static string DeviceProductName {
             get {
-                if(deviceProductName == null) {
-                    deviceProductName = Application.isEditor ? "EDITOR" : GetProductName();
-                    
-                }
+                if(deviceProductName == null) 
+                    deviceProductName = Application.isEditor ? "EDITOR" : GetSystemProperty("ro.product.name");
                 return deviceProductName;
             }
         }
         static string deviceProductName;
 
         /// <summary>
-        /// The manufacturer string of current device. Equivalent to android.os.Build.PRODUCT
+        /// The product string of current device. Equivalent to android.os.Build.PRODUCT
         /// Returns "EDITOR" when running in the Unity editor
         /// </summary>
         public static string DeviceProduct {
@@ -166,6 +165,9 @@ namespace MXR.SDK {
             }
         }
   
+        /// <summary>
+        /// Returns true if the current device is Pico 4 Ultra
+        /// </summary>
         public static bool IsPico4Ultra {
             get {
                 return Application.isEditor ? false : (DeviceProductName.Equals("sparrow", StringComparison.OrdinalIgnoreCase) || DeviceProduct.Equals("PICO 4 Enterprise Ultra", StringComparison.OrdinalIgnoreCase));
@@ -238,23 +240,26 @@ namespace MXR.SDK {
         /// </summary>
         public static bool IsOculus6DOF => IsOculusDevice && IsHeadset6DOF;
 
-        // PICO UI VERSION UTILS
+        #region OBSOLETE
         /// <summary>
         /// Returns Pico's UI version. returns "0.0.0" if current device is not a Pico device
         /// </summary>
+        [Obsolete("Use MXRPicoUtils.PUIVersion instead. This property may be removed in the future")]
         public static string PicoUIVersion =>
-            IsPicoDevice ? AndroidOSBuild.SafeGetStatic<string>("DISPLAY") : "0.0.0";
+            MXRPicoUtils.PUIVersion;
 
         /// <summary>
         /// Returns if current Pico UI version is 4.x.x if current device is a Pico device
         /// </summary>
+        [Obsolete("Use MXRPicoUtils.IsPUI4 instead. This property may be removed in the future")]
         public static bool IsPicoUI4 =>
-            PicoUIVersion.StartsWith("4");
+            MXRPicoUtils.IsPUI4;
 
         /// <summary>
         /// Returns whether the SDK is running on a device with 3DoF headset
         /// </summary>
         [Obsolete("Use IsHeadset3DOF instead. This proparty may be removed in the future.")]
         public static bool Is3DOF => IsHeadset3DOF;
+        #endregion
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs
@@ -1,0 +1,74 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Pico runtime utilities
+    /// </summary>
+    public static class MXRPicoUtils {
+        const string TAG = "MXRPicoUtils";
+
+        /// <summary>
+        /// Opens the Pico system update UI.
+        /// Ignored when called on a non Pico device
+        /// </summary>
+        public static void OpenSystemUpdateUI() {
+            if (MXRAndroidUtils.IsPicoDevice)
+                LaunchIntentAction("com.mightyimmersion.mightylibrary.intent.action.OPEN_SYSTEM_UPDATE");
+            else
+                Debug.unityLogger.LogWarning(TAG, "Not running on a Pico device. Ignoring PicoUtils.OpenSystemUpdateUI()");
+        }
+
+        /// <summary>
+        /// Returns Pico's PUI version. 
+        /// Always returns "0.0.0" on non Pico device
+        /// </summary>
+        public static string PUIVersion {
+            get {
+                if (MXRAndroidUtils.IsPicoDevice)
+                    return MXRAndroidUtils.AndroidOSBuild.SafeGetStatic<string>("DISPLAY");
+                else {
+                    Debug.unityLogger.LogWarning(TAG, "Not running on a Pico device. PicoUtils.PUIVersion returning 0.0.0");
+                    return "0.0.0";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns if current Pico UI version is 4.x.x 
+        /// Always returns false on non Pico device
+        /// </summary>
+        public static bool IsPUI4 {
+            get {
+                if(MXRAndroidUtils.IsPicoDevice)
+                    return PUIVersion.StartsWith("4");
+                else {
+                    Debug.unityLogger.LogWarning(TAG, "Not running on a Pico device. PicoUtils.IsPUI4 returning false");
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Launches an intent using the given action string
+        /// </summary>
+        /// <param name="action">The intent action</param>
+        internal static void LaunchIntentAction(string action) {
+            if (MXRAndroidUtils.IsPicoNeo3)
+                LaunchIntentActionViaPVRAdapter(action);
+            else
+                MXRAndroidUtils.LaunchIntentAction(action);
+        }
+
+        /// <summary>
+        /// Launches an intent using Pico's com.pvr.adapter using the given action string
+        /// </summary>
+        /// <param name="action">The intent action</param>
+        internal static void LaunchIntentActionViaPVRAdapter(string action) {
+            var intent = new AndroidJavaObject("android.content.Intent", "pvr.intent.action.ADAPTER");
+            intent.Call<AndroidJavaObject>("setPackage", "com.pvr.adapter");
+            intent.Call<AndroidJavaObject>("putExtra", "way", 2);
+            intent.Call<AndroidJavaObject>("putExtra", "args", new string[] { action });
+            MXRAndroidUtils.CurrentActivity.Call<AndroidJavaObject>("startService", intent);
+        }
+    }
+}

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs.meta
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 412eaa6f6f3f51f40a61e40b3cd10497
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* `MXRPicoUtils.LaunchIntentAction` allows launching an intent with an action string
* `OpenSystemUpdateUI` uses it with the OPEN_SYSTEM_UPDATE action

Deprecated with no breaking changes:
___MXRAndroidUtils.Device.cs___
* `PicoUIVersion` in favor of `MXRPicoUtils.PUIVersion`
* `IsPicoUI4` in favor of `MXRPicoUtils.IsPUI4`

___MXRAndroidUtils.Apps.cs___
* `LaunchAppWithIntentAction` in favor of `LaunchIntentAction` to match the native method name
* `GetSystemProperty` introduced. `GetProductName` is now deprecated and forwards the call to it with `"ro.product.name"` as the parameter

Fixed some incorrect code doc comments in MXRAndroidUtils.Device.cs