### PR TITLE
CU-868az54kh: Initial scene validation

### DIFF
--- a/Assets/MXR.SDK/Editor/Scene Export/ISceneExportValidator.cs
+++ b/Assets/MXR.SDK/Editor/Scene Export/ISceneExportValidator.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+
+namespace MXR.SDK.Editor {
+    public interface ISceneExportValidator {
+        List<Violation> Validate();
+    }
+}

--- a/Assets/MXR.SDK/Editor/Scene Export/ISceneExportValidator.cs.meta
+++ b/Assets/MXR.SDK/Editor/Scene Export/ISceneExportValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0070501a4bfbf9d4a992ac0778b357a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/Editor/Scene Export/SceneExportValidator.cs
+++ b/Assets/MXR.SDK/Editor/Scene Export/SceneExportValidator.cs
@@ -1,0 +1,108 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
+using UnityEngine.Rendering;
+
+namespace MXR.SDK.Editor {
+    public class SceneExportValidator : ISceneExportValidator {
+        /// <summary>
+        /// Returns a list of violations in the active scene
+        /// </summary>
+        public List<Violation> Validate() {
+            var violations = new List<Violation>();
+
+            var renderPipelineViolation = GetRenderPipelineViolation();
+            if (renderPipelineViolation != null)
+                violations.Add(renderPipelineViolation);
+
+            violations.AddRange(GetShaderViolations());
+            violations.AddRange(GetScriptViolations());
+            violations.AddRange(GetCameraViolations());
+            violations.AddRange(GetLightViolations());
+            violations.AddRange(GetEventSystemViolations());
+
+            return violations;
+        }
+
+        private Violation GetRenderPipelineViolation() {
+            var renderPipelineAsset = GraphicsSettings.defaultRenderPipeline;
+            var violation = new Violation(
+                Violation.Types.UnsupportedRenderPipeline, 
+                false, 
+                "Only Universal Render Pipeline is supported.", 
+                null
+            );
+            if (renderPipelineAsset != null && renderPipelineAsset.GetType().Name == "UniversalRenderPipelineAsset")
+                return null;
+            else
+                return violation;
+        }
+
+        private List<Violation> GetShaderViolations() {
+            var dependencies = AssetDatabase.GetDependencies(new string[] {
+                SceneManager.GetActiveScene().path
+            });
+            var unsupportedMaterials = dependencies
+                .Where(x => x.EndsWith(".mat"))
+                .Select(x => AssetDatabase.LoadAssetAtPath<Material>(x))
+                .Where(x => !x.shader.name.Equals("Hidden/"))
+                .Where(x => !x.shader.name.StartsWith("Universal Render Pipeline/"))
+                .Where(x => !x.shader.name.StartsWith("Unlit/"))
+                .Where(x => !x.shader.name.StartsWith("UI/"))
+                .Where(x => !x.shader.name.StartsWith("Sprites/"))
+                .Where(x => !x.shader.name.StartsWith("Skybox/"));
+            return unsupportedMaterials.Select(x => new Violation(
+                Violation.Types.UnsupportedShader,
+                false,
+                "Only default URP, Unlit, UI, Sprites and Skybox shaders are supported.",
+                x)).ToList();
+        }
+
+        private List<Violation> GetScriptViolations() {
+            var components = Object.FindObjectsOfType<MonoBehaviour>()
+                    .Where(x => !x.GetType().FullName.StartsWith("TMPro"))
+                    .Where(x => !x.GetType().FullName.StartsWith("UnityEngine"));
+            return components.Select(x => new Violation(
+                Violation.Types.CustomScriptFound,
+                false,
+                "Custom scripts and components are not supported. Please remove them from the scene.",
+                x
+            )).ToList();
+        }
+
+        private List<Violation> GetCameraViolations() {
+            var cameras = Object.FindObjectsOfType<Camera>();
+            return cameras.Select(x => new Violation(
+                Violation.Types.CameraFound,
+                false,
+                "Scene cameras are not supported. Please remove cameras from the scene.",
+                x
+            )).ToList();
+        }
+
+        private List<Violation> GetLightViolations() {
+            var nonBakedLights = Object.FindObjectsOfType<Light>()
+                .Where(x => x.lightmapBakeType != LightmapBakeType.Baked).ToList();
+            return nonBakedLights.Select(x => new Violation(
+                Violation.Types.NonBakedLight,
+                true,
+                "Realtime and Mixed lights are not recommended. Consider lightmapping your scene with baked lights.",
+                x
+            )).ToList();
+        }
+
+        private List<Violation> GetEventSystemViolations() {
+            var eventSystems = Object.FindObjectsOfType<EventSystem>();
+            return eventSystems.Select(x => new Violation(
+                Violation.Types.EventSystemFound,
+                false,
+                "There cannot be an EventSystem on the scene. Please remove them from the scene.",
+                x
+            )).ToList();
+        }
+    }
+}

--- a/Assets/MXR.SDK/Editor/Scene Export/SceneExportValidator.cs.meta
+++ b/Assets/MXR.SDK/Editor/Scene Export/SceneExportValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd119d1fa2fbcb046b1eca53e9c30226
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/Editor/Scene Export/SceneExportWindow.cs
+++ b/Assets/MXR.SDK/Editor/Scene Export/SceneExportWindow.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 using UnityEditor;
 
@@ -7,56 +10,139 @@ using UnityEngine.SceneManagement;
 
 namespace MXR.SDK.Editor {
     public class SceneExportWindow : EditorWindow {
-        private const string EXTENSION = "mxrus";
+        const int H1 = 16;
+        const int H2 = 14;
+        const int H3 = 12;
 
-        private string exportPath;
-        private bool keepExportDir;
+        const int WIDTH = 800;
+        const int HEIGHT = 600;
+        const string EXTENSION = "mxrus";
+
+        string exportPath;
+        bool keepExportDir;
+        List<Violation> violations;
+        Vector2 scrollPos;
 
         [MenuItem("Tools/MXR/Scene Exporter")]
         public static void OpenWindow() {
             var window = (SceneExportWindow)GetWindow(typeof(SceneExportWindow));
             window.Show();
             window.titleContent = new GUIContent("MXR Scene Exporter");
-            window.minSize = new Vector2(400, 200);
-            window.maxSize = new Vector2(400, 200);
+            window.minSize = new Vector2(WIDTH, HEIGHT);
+            window.maxSize = new Vector2(WIDTH, HEIGHT);
         }
 
-        private void OnGUI() {
-            var activeScene = SceneManager.GetActiveScene();
+        void OnGUI() {
+            // Start a scroll view, the entire windows contents are scrollable
+            EditorGUILayout.BeginVertical();
+            scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Width(WIDTH), GUILayout.Height(HEIGHT));
 
+            // Early out if the current scene isn't saved
+            var activeScene = SceneManager.GetActiveScene();
             if (activeScene == null || string.IsNullOrEmpty(activeScene.path)) {
-                GUILayout.Space(20);
-                Label("You're on an unsaved scene. Please save to export.", Color.red);
+                Label("You're on an unsaved scene. Please save the scene to export.", Color.red, H1);
+                EditorGUILayout.EndScrollView();
+                EditorGUILayout.EndVertical();
                 return;
             }
 
-            GUILayout.Space(20);
             Label(
                 "This tool allows you to export your Unity scene as .mxrus files." +
-                "\n\nThese files can then be deployed via the ManageXR dashboard to customize your homescreen environment."
+                "\n\nThese files can then be deployed via the ManageXR dashboard to customize your homescreen environment.",
+                H1
             );
-            GUILayout.Space(40);
-            keepExportDir = GUILayout.Toggle(keepExportDir, "Keep intermediate export directory");
-            GUILayout.Space(10);
-            if (GUILayout.Button("Export this scene")) {
-                var directory = Application.dataPath.Replace("Assets", "");
-                var defaultName = Path.GetFileNameWithoutExtension(activeScene.path);
-                exportPath = EditorUtility.SaveFilePanel("Export scene", directory, defaultName, EXTENSION);
-                if (!string.IsNullOrEmpty(exportPath)) {
-                    SceneExporter.ExportScene(activeScene.path, exportPath, BuildTarget.Android, !keepExportDir);
-                }
-                else {
-                    Debug.Log("Export path selection cancelled");
+
+            GUILayout.Space(20);
+            if (GUILayout.Button("Validate Scene"))
+                violations = new SceneExportValidator().Validate();
+
+            ShowViolationsSummary();
+
+            if (violations != null && violations.Where(x => !x.IsWarning).Count() == 0) {
+                GUILayout.Space(10);
+                keepExportDir = GUILayout.Toggle(keepExportDir, "Keep intermediate export directory");
+                GUILayout.Space(10);
+                if (GUILayout.Button("Export Scene")) {
+                    // Validate again before attempting export in case violating changes
+                    // were made after successful validation
+                    violations = new SceneExportValidator().Validate();
+                    if (violations.Where(x => !x.IsWarning).Count() > 0)
+                        return;
+
+                    violations = null;
+                    var directory = Application.dataPath.Replace("Assets", "");
+                    var defaultName = Path.GetFileNameWithoutExtension(activeScene.path);
+                    exportPath = EditorUtility.SaveFilePanel("Export scene", directory, defaultName, EXTENSION);
+                    if (!string.IsNullOrEmpty(exportPath))
+                        SceneExporter.ExportScene(activeScene.path, exportPath, BuildTarget.Android, !keepExportDir);
+                    else
+                        Debug.Log("Export path selection cancelled");
                 }
             }
+
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
         }
 
-        private void Label(string msg) => Label(msg, Color.white);
+        void ShowViolationsSummary() {
+            if (violations == null)
+                return;
+            
+            // Draw a horizontal divider with 20 padding
+            EditorGUILayout.Space(20);
+            var rect = EditorGUILayout.GetControlRect(false, 1);
+            EditorGUI.DrawRect(rect, Color.gray);
+            EditorGUILayout.Space(20);
 
-        private void Label(string msg, Color color) {
+            if (violations.Count == 0) {
+                Label("Scene validated. You can export now!");
+                return;
+            }
+
+            // Heading
+            Label("Your scene has some issues.", H1);
+            EditorGUILayout.Space(5);
+            Label("The ones highlighted RED must be addressed for export.\n" +
+            "Others may be ignored but it is recommended you fix them.", H2);
+            EditorGUILayout.Space(20);
+
+            var violationTypes = violations.Select(x => x.Type).Distinct().ToArray();
+
+            for (int i = 0; i < violationTypes.Count(); i++) {
+                // Print the violation description
+                var first = violations.First(x => x.Type == violationTypes[i]);
+                if (first.IsWarning)
+                    Label((i + 1) + ". " + first.Description, H2);
+                else
+                    Label((i + 1) + ". " + first.Description, Color.red, H2);
+
+                EditorGUILayout.Space(10);
+
+                // Show the relevant objects of the violation
+                foreach (var violation in violations.Where(x => x.Type == violationTypes[i])) {
+                    if (violation.Object)
+                        EditorGUILayout.ObjectField(violation.Object, violation.Object.GetType(), true);
+                    EditorGUILayout.Space(10);
+                }
+                EditorGUILayout.Space(10);
+            }
+            return;
+        }
+
+        void Label(string msg, int size = H3) {
             var style = new GUIStyle() {
-                normal = new GUIStyleState { textColor = color },
-                wordWrap = true
+                normal = new GUIStyleState { textColor = EditorGUIUtility.isProSkin ? Color.white : Color.black },
+                wordWrap = true,
+                fontSize = size
+            };
+            GUILayout.Label(msg, style);
+        }
+
+        void Label(string msg, Color color, int size = H3) {
+            var style = new GUIStyle() {
+                normal = new GUIStyleState { textColor = color == null ? (EditorGUIUtility.isProSkin ? Color.white : Color.black) : color },
+                wordWrap = true,
+                fontSize = size
             };
             GUILayout.Label(msg, style);
         }

--- a/Assets/MXR.SDK/Editor/Scene Export/Violation.cs
+++ b/Assets/MXR.SDK/Editor/Scene Export/Violation.cs
@@ -1,0 +1,57 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK.Editor {
+    public class Violation {
+        /// <summary>
+        /// Enumerates all the difference kind of violations 
+        /// a scene can have that can prevent or affect export.
+        /// </summary>
+        public enum Types {
+            /// <summary>
+            /// If the project is using an unsupported render pipeline.
+            /// Only the Universal Rendering Pipeline is supported.
+            /// </summary>
+            UnsupportedRenderPipeline,
+
+            /// <summary>
+            /// If a material is using an unsupported shader.
+            /// Only URP shaders and select in-built shaders are supported.
+            /// </summary>
+            UnsupportedShader,
+
+            /// <summary>
+            /// If a gameobject on the scene has a custom/user-authored script
+            /// </summary>
+            CustomScriptFound,
+
+            /// <summary>
+            /// If the scene has a camera we prevent export 
+            /// </summary>
+            CameraFound,
+
+            /// <summary>
+            /// If the scene has a realtime or mixed light. This doesn't block export
+            /// but is used to show a warning about potential performance issues.
+            /// </summary>
+            NonBakedLight,
+
+            /// <summary>
+            /// If the scene has an EventSystem. The homescreen has its own and it doesn't
+            /// allow another.
+            /// </summary>
+            EventSystemFound
+        }
+
+        public Types Type { get; private set; }
+        public bool IsWarning { get; private set; }
+        public string Description { get; private set; }
+        public Object Object { get; private set; }
+
+        public Violation(Types type, bool isWarning, string description, Object obj) {
+            Type = type;
+            IsWarning = isWarning;
+            Description = description;
+            Object = obj;
+        }
+    }
+}

--- a/Assets/MXR.SDK/Editor/Scene Export/Violation.cs.meta
+++ b/Assets/MXR.SDK/Editor/Scene Export/Violation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bac1b9a2de3e3574f8f10e1984502f26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SceneExportValidator goes through the scene object and dependencies and returns a list of violations that can be used to prevent export.

SceneExportWindow now uses SceneExportValidator for validating a scene, showing violations and helping the user fix them before allowing export.

SceneExporter class no longer filters out .cs files. AssetBundles do support packaging scripts (although they won't compile) and SceneExportValidator now does the job of preventing the user from exporting the scene with scripts instead.