### PR TITLE
CU-868brkjk3: Gate DeviceData code based on admin app version

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
+++ b/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
@@ -250,6 +250,27 @@ public class NativeUtils {
         }
     }
 
+    public String getInstalledAdminAppVersionName() {
+        try {
+            PackageManager pm = mContext.getPackageManager();
+            List<PackageInfo> packages = pm.getInstalledPackages(0);
+
+            String adminAppPackageName = getInstalledAdminAppPackageName();
+            if (adminAppPackageName == null) return null;
+
+            for (PackageInfo packageInfo : packages) {
+                if (!packageInfo.packageName.equals(adminAppPackageName)) continue;
+
+                return packageInfo.versionName;
+            }
+
+            return null;
+        } catch (Exception e) {
+            Log.e("NativeUtils", e.toString());
+            return null;
+        }
+    }
+
     public String getSystemProperty(String key) {
         String result = "";
         try {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -98,7 +98,8 @@ namespace MXR.SDK {
             messenger.OnBoundStatusToAdminAppChanged += x =>
                 OnAvailabilityChange?.Invoke(x);
 
-            InitializeDeviceData();
+            if(MXRAndroidUtils.IsDeviceDataSupported)
+                InitializeDeviceData();
             InitializeRuntimeSettingsSummary();
             InitializeDeviceStatus();
             RefreshWifiConnectionStatus();

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -5,6 +5,11 @@ using UnityEngine;
 namespace MXR.SDK {
     public static partial class MXRAndroidUtils {
         /// <summary>
+        /// The minimum Admin App version that supports the <see cref="DeviceData"/> features
+        /// </summary>
+        public static Version MinAdminAppVersionSupportingDeviceData => new Version(1, 7, 74);
+
+        /// <summary>
         /// Gets the class name using the package name of an app
         /// </summary>
         /// <param name="pkgName"></param>
@@ -92,14 +97,65 @@ namespace MXR.SDK {
         public static void LaunchIntentAction(string intentAction) =>
             NativeUtils.SafeCall<bool>("launchIntentAction", intentAction);
 
+        /// <summary>
+        /// The package name of the Admin App installed on an Android device
+        /// </summary>
+        /// <returns>Returns null if unsuccessful</returns>
+        public static string GetAdminAppPackageName() {
+            if(NativeUtils != null)
+                return NativeUtils.SafeCall<string>("getInstalledAdminAppPackageName");
+            return null;
+        }
 
-        public static string GetAdminAppPackageName() =>
-            NativeUtils.SafeCall<string>("getInstalledAdminAppPackageName");
-
+        /// <summary>
+        /// The version code of the Admin App installed on an Android device
+        /// </summary>
+        /// <returns>Returns -1 if unsuccessful</returns>
         public static int GetAdminAppVersionCode() {
             if (NativeUtils != null)
                 return NativeUtils.SafeCall<int>("getInstalledAdminAppVersionCode");
             return -1;
+        }
+
+        /// <summary>
+        /// The version name string of the Admin App installed on an Android device
+        /// </summary>
+        /// <returns>Returns null if unsuccessful</returns>
+        public static string GetAdminAppVersionName() {
+            if (NativeUtils != null)
+                return NativeUtils.SafeCall<string>("getInstalledAdminAppVersionName");
+            return null;
+        }
+
+        /// <summary>
+        /// The <see cref="Version"/> of the Admin App installed on an Android device
+        /// </summary>
+        /// <returns>Returns null if the version name of the installed Admin App could not be retrieved
+        /// or if the retrieved value is invalid.
+        /// </returns>
+        public static Version GetAdminAppVersion() {
+            var versionName = GetAdminAppVersionName();
+            if (versionName == null)
+                return null;
+
+            // The version name may have a hyphen, e.g. "1.0.0-test"
+            var versionString = versionName.Split('-')[0];
+            if (Version.TryParse(versionString, out var version)) 
+                return version;
+            return null;
+        }
+
+        /// <summary>
+        /// Whether the Admin App installed on an Android device supports the <see cref="DeviceData"/> features
+        /// </summary>
+        /// <returns>Returns false if the version of the installed Admin App could not be retrieved</returns>
+        public static bool IsDeviceDataSupported {
+            get {
+                var version = GetAdminAppVersion();
+                if (version == null)
+                    return false;
+                return version >= MinAdminAppVersionSupportingDeviceData;
+            }
         }
 
         /// <summary>

--- a/Assets/MXR.SDK/Runtime/MXRManager.cs
+++ b/Assets/MXR.SDK/Runtime/MXRManager.cs
@@ -71,9 +71,11 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log("Waiting to connect to Admin App");
                 await Task.Delay(100);
             }
-
+            
             // Next we wait for the DeviceData, DeviceStatus and RuntimeSettingsSummary to become non null.
-            if (System.DeviceData == null)
+            if (!MXRAndroidUtils.IsDeviceDataSupported) 
+                Debug.unityLogger.Log(LogType.Log, TAG, $"{MXRAndroidUtils.GetAdminAppVersionName()} does not support DeviceData");
+            else if (System.DeviceData == null)
                 Debug.unityLogger.Log(LogType.Log, TAG, "Waiting for MXRManager.System.DeviceData to be initialized.");
 
             if (System.DeviceStatus == null)
@@ -83,7 +85,9 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Log, TAG, "Waiting for MXRManager.System.RuntimeSettingsSummary to be initialized.");
 
             bool hadToWait = false;
-            while (System.DeviceData == null || System.DeviceStatus == null || System.RuntimeSettingsSummary == null) {
+            while ((MXRAndroidUtils.IsDeviceDataSupported && System.DeviceData == null)
+            || System.DeviceStatus == null 
+            || System.RuntimeSettingsSummary == null) {
                 hadToWait = true;
                 await Task.Delay(100);
             }


### PR DESCRIPTION
NativeUtils.java now has a getInstalledAdminAppVersionName() method to retrieve the version name of the admin app

MXRAndroidUtils changes:
* MinAdminAppVersionSupportingDeviceData defines 1.7.74 as the minimum admin app version supporting DeviceData
* IsDeviceDataSupported returns if the admin app supports DeviceData features.
* GetAdminAppVersionName() that returns the version name as a string
* GetAdminAppVersion() that returns the version as a Version object

MXRManager now waits for DeviceData for its initialization only if the installed admin app supports DeviceData features.

MXRAndroidSystem initializes DeviceData (including initializing from the last cached json) only if admin app supports DeviceData.

Note: There's no version check on MXRAndroidSystem.cs#187. This allows DeviceData to start coming in during homescreen runtime the admin app updates to a version that supports DeviceData.