### PR TITLE
Added editor checks to GetAdminAppVersion() and IsDeviceDataSupported

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -130,10 +130,15 @@ namespace MXR.SDK {
         /// <summary>
         /// The <see cref="Version"/> of the Admin App installed on an Android device
         /// </summary>
-        /// <returns>Returns null if the version name of the installed Admin App could not be retrieved
+        /// <returns>
+        /// Returns null in the Unity Editor
+        /// On Android, returns null if the version name of the installed Admin App could not be retrieved
         /// or if the retrieved value is invalid.
         /// </returns>
         public static Version GetAdminAppVersion() {
+            if (Application.isEditor)
+                return null;
+
             var versionName = GetAdminAppVersionName();
             if (versionName == null)
                 return null;
@@ -148,9 +153,17 @@ namespace MXR.SDK {
         /// <summary>
         /// Whether the Admin App installed on an Android device supports the <see cref="DeviceData"/> features
         /// </summary>
-        /// <returns>Returns false if the version of the installed Admin App could not be retrieved</returns>
+        /// <returns>
+        /// Returns true in the Unity Editor.
+        /// On Android, returns false if the version of the installed Admin App could not be retrieved 
+        /// or if the version is below <see cref="MinAdminAppVersionSupportingDeviceData"/>
+        /// </returns>
         public static bool IsDeviceDataSupported {
             get {
+                // When on the editor, we simulate DeviceData using deviceData.json included in the samples
+                if (Application.isEditor)
+                    return true;
+
                 var version = GetAdminAppVersion();
                 if (version == null)
                     return false;


### PR DESCRIPTION
When running in the Unity Editor, we always support DeviceData because the sample deviceData.json is used by MXREditorSystem for simulating DeviceData.

A similar editor check has been added to GetAdminAppVersion() which returns null when running in the editor.

Not having these checks would cause the code to execute JNI calls when in the editor which fails.