### PR TITLE
CU-868d7ju6z: User Area Provider Embedding

### DIFF
--- a/Assets/MXR.SDK/MXRUS/Editor/SceneExportViolation.cs
+++ b/Assets/MXR.SDK/MXRUS/Editor/SceneExportViolation.cs
@@ -42,12 +42,12 @@ namespace MXR.SDK.Editor {
             EventSystemFound,
 
             /// <summary>
-            /// The the scene doesn't have any defined user area
+            /// If the scene doesn't have any user area provider
             /// </summary>
             NoUserAreaProviderFound,
 
             /// <summary>
-            /// If multiple user areas are defined in the scene.
+            /// If the scene has multiple user area providers
             /// </summary>
             MultipleUserAreaProvidersFound
         }

--- a/Assets/MXR.SDK/MXRUS/Embeddings.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cc85dc6c0312d34bac5ffca9d166c1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/GizmosX.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/GizmosX.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    public static class GizmosX {
+        public static void DrawConcentricCirclesXZ(Vector3 center, float radius, int perimeterSegments, int count) {
+            float distanceStep = radius / count;
+
+            for (int i = 1; i <= count; i++) {
+                DrawCircleXZ(center, distanceStep * i, perimeterSegments);
+            }
+        }
+
+        public static void DrawCircleXZ(Vector3 center, float radius, int perimeterSegments) {
+            float angleStep = 360f / perimeterSegments;
+            Vector3 prevPoint = center + new Vector3(Mathf.Cos(0), 0, Mathf.Sin(0)) * radius;
+
+            for (int i = 1; i <= perimeterSegments; i++) {
+                float angle = angleStep * i * Mathf.Deg2Rad;
+                Vector3 nextPoint = center + new Vector3(Mathf.Cos(angle), 0, Mathf.Sin(angle)) * radius;
+                Gizmos.DrawLine(prevPoint, nextPoint);
+                prevPoint = nextPoint;
+            }
+        }
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/GizmosX.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/GizmosX.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 987790a9fb158d44f80a5cd46f910f25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Providers.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Providers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87c066ba456225c49b64e239e0c69e7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Providers/IUserAreaProvider.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Providers/IUserAreaProvider.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Metadata embedding for the user area in an MXRUS environment
+    /// </summary>
+    interface IUserAreaProvider {
+        /// <summary>
+        /// The start position of the user in this environment
+        /// </summary>
+        Vector3 UserStartPosition { get; }
+
+        /// <summary>
+        /// The start rotation (direction) of the user in this environment.
+        /// </summary>
+        Quaternion UserStartRotation { get; }
+
+        /// <summary>
+        /// The distance the user is allowed to walk around in relative to <see cref="UserStartPosition"/>
+        /// </summary>
+        float UserWalkableRadius { get; }
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Providers/IUserAreaProvider.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Providers/IUserAreaProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c04d824796927c94faeba3798c4a8785
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Providers/MonoUserAreaProvider.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Providers/MonoUserAreaProvider.cs
@@ -1,0 +1,75 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Used to configure the user position and rotation, and walkable radius using a GameObject on the scene.
+    /// Using Gizmos, it draws a primitive avatar at the start position and other visuals 
+    /// representing start rotation and walkable radius.
+    /// </summary>
+    [ExecuteInEditMode]
+    public class MonoUserAreaProvider : MonoBehaviour, IUserAreaProvider {
+        // consts used for creating avatar gizmos
+        private const float BODY_HEIGHT = 1.4f;
+        private const float HEAD_RADIUS = 0.2f;
+        private const float BODY_WIDTH = 0.4f;
+        
+        private const float ARM_LENGTH = BODY_HEIGHT / 2;
+        private const float ARM_WIDTH = 0.2f;
+
+        private const int PERIMETER_SEGMENTS = 32;
+        private const int RING_COUNT = 10;
+
+        // Interface properties
+        public Vector3 UserStartPosition => transform.position;
+        public Quaternion UserStartRotation => transform.rotation;
+        public float UserWalkableRadius => walkableRadius;
+
+        // User configurable
+        [SerializeField] private float walkableRadius = 5;
+
+        private void Update() {
+            // At runtime the MXR homescreen only uses the interface properties
+            // The code in this method is only required in editor mode during environment creation.
+            if (Application.isPlaying) return;
+
+            // Allow rotation only along the Y axis
+            transform.localEulerAngles = new Vector3(0, transform.localEulerAngles.y, 0);
+            if (transform.parent != null)
+                transform.parent = null;
+
+            // Prevent resizing of the transform so the visuals don't get skewed or scaled
+            transform.localScale = Vector3.one;
+        }
+
+        private void OnDrawGizmos() {
+            Matrix4x4 rotationMatrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.localScale);
+            Gizmos.matrix = rotationMatrix;
+
+            // Draw walkable area
+            Gizmos.color = Color.yellow;
+            GizmosX.DrawConcentricCirclesXZ(Vector3.zero, walkableRadius, PERIMETER_SEGMENTS, RING_COUNT);
+
+            // Draw lines to show forward and right directions relative to the avatars rotation
+            Gizmos.color = Color.white;
+            Gizmos.DrawLine(Vector3.zero, Vector3.forward * 2);
+            Gizmos.DrawLine(Vector3.zero, Vector3.right * 2);
+
+            // Draw avatar body
+            Gizmos.color = Color.cyan;
+            Gizmos.DrawCube(Vector3.up * BODY_HEIGHT / 2, new Vector3(BODY_WIDTH, BODY_HEIGHT, BODY_WIDTH));
+            Gizmos.DrawCube(
+                (Vector3.up * (BODY_HEIGHT - ARM_WIDTH / 2)) + (Vector3.right * (BODY_WIDTH / 2 + ARM_LENGTH / 2)),
+                new Vector3(ARM_LENGTH, ARM_WIDTH, ARM_WIDTH)
+            );
+            Gizmos.DrawCube(
+                (Vector3.up * (BODY_HEIGHT - ARM_WIDTH / 2)) + (Vector3.left * (BODY_WIDTH / 2 + ARM_LENGTH / 2)),
+                new Vector3(ARM_LENGTH, ARM_WIDTH, ARM_WIDTH)
+            );
+            Gizmos.DrawSphere(Vector3.up * BODY_HEIGHT + (transform.up * HEAD_RADIUS), HEAD_RADIUS);
+
+            // Reset Gizmos class
+            Gizmos.color = Color.white;
+            Gizmos.matrix = Matrix4x4.identity;
+        }
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Providers/MonoUserAreaProvider.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Providers/MonoUserAreaProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2983b77ad6a235043a1eb8ac72976e10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/com.mxr.unity.sdk.mxrus.embeddings.asmdef
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/com.mxr.unity.sdk.mxrus.embeddings.asmdef
@@ -1,9 +1,6 @@
 {
-    "name": "com.mxr.unity.sdk.mxrus.editor",
-    "references": [
-        "GUID:0a6056b72db1f26499a3860e9a71e042",
-        "GUID:1af6960767f2322479cb09771bdaefa6"
-    ],
+    "name": "com.mxr.unity.sdk.mxrus.embeddings",
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Assets/MXR.SDK/MXRUS/Embeddings/com.mxr.unity.sdk.mxrus.embeddings.asmdef.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/com.mxr.unity.sdk.mxrus.embeddings.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1af6960767f2322479cb09771bdaefa6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* MonoUserAreaProvider component (implements IUserAreaProvider) has been introduced.

* It allows the environment to define the start position, start rotation and walkable radius for the user.

* There must be one (and only one) instance of MonoUserAreaProvider on the scene. To validate this two new violation types have been introduced: NoUserAreaProviderFound and MultipleUserAreaProvidersFound

* Since MonoUserAreaProvider is a script, it has been placed in a separate asmdef named com.mxr.unity.sdk.mxrus.embeddings which has been added to the list of supported assemblies in SceneExportValidator when checking for scripts.

* The code for validating custom scripts has also been made simpler by checking assembly name instead of DLL path. Checks for UnityEngine.UI.dll as it is not required.