### PR TITLE
CU-868d7ju6z: Logo Marker embedding

### DIFF
--- a/Assets/MXR.SDK/MXRUS/Editor/SceneExportValidator.cs
+++ b/Assets/MXR.SDK/MXRUS/Editor/SceneExportValidator.cs
@@ -104,6 +104,7 @@ namespace MXR.SDK.Editor {
             var allowedAssemblies = new string[] {
                 "Unity.TextMeshPro",
                 "Unity.RenderPipelines.Universal.Runtime",
+                "UnityEngine.UI",
                 "com.mxr.unity.sdk.mxrus.embeddings"
             };
 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20b9bd219ffa75d47a296eab3932a237
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/ILogoMarker.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/ILogoMarker.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Marks an object to show a logo on
+    /// </summary>
+    public interface ILogoMarker {
+        /// <summary>
+        /// The logo type to be shown
+        /// </summary>
+        LogoMarkerType LogoMarkerType { get; }
+
+        /// <summary>
+        /// Sets the logo Texture2D on the object
+        /// </summary>
+        /// <param name="texture"></param>
+        void SetLogo(Texture2D texture);
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/ILogoMarker.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/ILogoMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f76d7d2e99c7d1a43a3b2a90b3a48af6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/LogoMarkerType.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/LogoMarkerType.cs
@@ -1,0 +1,18 @@
+﻿namespace MXR.SDK {
+    /// <summary>
+    /// Refers to a logo deployed on the ManageXR dashboard
+    /// </summary>
+    public enum LogoMarkerType {
+        /// <summary>
+        /// The top logo added to the configuration. This is the same logo that is
+        /// shown above the library panel in the ManageXR homescreen.
+        /// </summary>
+        CONFIGURATION_TOP,
+
+        /// <summary>
+        /// The bottom logo added to the configuration. This is the same logo that is
+        /// shown below the toolbar in the ManageXR homescreen.
+        /// </summary>
+        CONFIGURATION_BOTTOM
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/LogoMarkerType.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/LogoMarkerType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5f487c88f6842d4a9dea11cd733cd32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Marks a UI GameObject with Image component for showing a logo
+    /// </summary>
+    [RequireComponent(typeof(Image))]
+    public class MonoImageLogoMarker : MonoBehaviour, ILogoMarker {
+        [SerializeField] LogoMarkerType _logoMarkerType;
+
+        public LogoMarkerType LogoMarkerType => _logoMarkerType;
+
+        private Image _image;
+
+        private void Awake() {
+            _image = GetComponent<Image>();
+        }
+
+        public void SetLogo(Texture2D texture) {
+            _image.sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.one / 2);
+        }
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoImageLogoMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7263d8c6294a84e46b79bb4cf074d8ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Marks a 3D GameObject with a Renderer for showing a logo
+    /// </summary>
+    [RequireComponent(typeof(Renderer))]
+    public class MonoRendererLogoMarker : MonoBehaviour, ILogoMarker {
+        [SerializeField] LogoMarkerType _logoMarkerType;
+
+        public LogoMarkerType LogoMarkerType => _logoMarkerType;
+
+        private Renderer _renderer;
+
+        private void Awake () {
+            _renderer = GetComponent<Renderer>();
+        }
+
+        public void SetLogo(Texture2D texture) {
+            _renderer.material.mainTexture = texture;
+        }
+    }
+}

--- a/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs.meta
+++ b/Assets/MXR.SDK/MXRUS/Embeddings/Markers/MonoRendererLogoMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ddafa9aabafd7440823e241d59d3af5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* MonoRendererLogoMarker and MonoImageLogoMarkers (both implement ILogoMarker) have been introduced to mark gameobjects with Renderer and Image components respectively for showing logos.

* UnityEngine.UI has been re-added to the allowed assemblies list to allow the presence of components such as GraphicRaycaster, CanvasScaler and Image in the scene that are required to create a canvas