### PR TITLE
CU-868d5ju8b: Consume New Controller Api

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/DeviceTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/DeviceTypes.cs
@@ -10,5 +10,6 @@ namespace MXR.SDK {
         public string firmwareVersion;
         public string model;
         public string manufacturer;
+        public ControllerData controllerData;
     }
 }


### PR DESCRIPTION
### TL;DR

Added controller data field to DeviceData class.

### What changed?

Added a new `controllerData` field of type `ControllerData` to the `DeviceData` class in the DeviceTypes.cs file. 


### Why make this change?

This change allows us to utilize and consume the new Controller Battery API changes that were made on the Admin App side. 