### PR TITLE
CU-868efuftr: Add Auto Center To Runtime Settings

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -316,6 +316,12 @@ namespace MXR.SDK {
         /// The theme to be used for the homescreen
         /// </summary>
         public CustomHomeScreenColors colors = new CustomHomeScreenColors();
+        
+        /// <summary>
+        /// If true, the Library Panel will follow the users head, staying in your field of view.
+        /// Otherwise, the Library Panel will stay in a fixed location and the user will need to recenter manually.
+        /// </summary>
+        public bool autoCenterLibraryPanel;
     }
 
     /// <summary>


### PR DESCRIPTION
### TL;DR

Added a new `autoCenterLibraryPanel` boolean property to the `CustomLauncherSettings` class.

### What changed?

Added a new boolean property `autoCenterLibraryPanel` to the `CustomLauncherSettings` class in `RuntimeTypes.cs`. This property includes XML documentation explaining that when enabled, the Library Panel will follow the user's head to stay in their field of view, and when disabled, the panel will remain in a fixed location requiring manual recentering.
