### PR TITLE
Remove Android Compilation Symbols

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,4 +1,3 @@
-#if UNITY_ANDROID
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -416,4 +415,3 @@ namespace MXR.SDK {
         }
     }
 }
-#endif


### PR DESCRIPTION
### TL;DR

Removed Android platform conditional compilation directives from MXRAndroidSystem.cs as it was causing CI to fail in cases where the Editor was not set to Android. 

### What changed?

- Removed `#if UNITY_ANDROID` and `#endif` directives that were wrapping the entire MXRAndroidSystem.cs file

