### PR TITLE
CU-868evjr20: Screen Casting Rename

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
@@ -50,8 +50,8 @@ public class AdminAppMessageTypes {
 
     public static final int OVERRIDE_KIOSK_APP = 20;
 
-    public static final int GET_STREAMING_CODE = 21;
-    public static final int STREAMING_CODE = 21000;
+    public static final int GET_CASTING_CODE = 21;
+    public static final int CASTING_CODE = 21000;
     
-    public static final int STOP_STREAMING = 22;
+    public static final int STOP_CASTING = 22;
 }

--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -204,12 +204,12 @@ public class AdminAppMessengerManager {
         return sendMessage(AdminAppMessageTypes.HOME_SCREEN_STATE, stateJson);
     }
     
-    public boolean requestStreamingCodeAsync() {
-        return sendMessage(AdminAppMessageTypes.GET_STREAMING_CODE);
+    public boolean requestCastingCodeAsync() {
+        return sendMessage(AdminAppMessageTypes.GET_CASTING_CODE);
     }
     
-    public boolean stopStreamingAsync() {
-        return sendMessage(AdminAppMessageTypes.STOP_STREAMING);
+    public boolean stopCastingAsync() {
+        return sendMessage(AdminAppMessageTypes.STOP_CASTING);
     }
 
     public boolean sendMessage(int what) {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -22,7 +22,7 @@ namespace MXR.SDK {
             public const int DEVICE_STATUS = 5000;
             public const int HANDLE_COMMAND = 6000;
             public const int GET_HOME_SCREEN_STATE = 15000;
-            public const int STREAMING_CODE = 21000;
+            public const int CASTING_CODE = 21000;
         }
 
         private void OnMessageFromAdminApp(int what, string json) {
@@ -44,8 +44,8 @@ namespace MXR.SDK {
                 case AdminAppMessageTypes.DEVICE_DATA:
                     HandleDeviceData(json);
                     break;
-                case AdminAppMessageTypes.STREAMING_CODE:
-                    HandleStreamingCode(json);
+                case AdminAppMessageTypes.CASTING_CODE:
+                    HandleCastingCode(json);
                     break;
                 case AdminAppMessageTypes.HANDLE_COMMAND:
                     ProcessCommandJson(json);
@@ -142,15 +142,15 @@ namespace MXR.SDK {
             LogIfEnabled(LogType.Log, "DeviceData updated.");
         }
 
-        private void HandleStreamingCode(string json) {
-            var streamingCodeData = JsonConvert.DeserializeObject<StreamingCodeStatus>(json);
-            if (streamingCodeData == null) {
+        private void HandleCastingCode(string json) {
+            var castingCodeData = JsonConvert.DeserializeObject<CastingCodeStatus>(json);
+            if (castingCodeData == null) {
                 return;
             }
 
-            StreamingCodeStatus = streamingCodeData;
-            OnStreamingCodeStatusChanged?.Invoke(streamingCodeData);
-            LogIfEnabled(LogType.Log, "StreamingCodeStatus updated.");
+            CastingCodeStatus = castingCodeData;
+            OnCastingCodeStatusChanged?.Invoke(castingCodeData);
+            LogIfEnabled(LogType.Log, "CastingCodeStatus updated.");
         }
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -64,7 +64,7 @@ namespace MXR.SDK {
         public RuntimeSettingsSummary RuntimeSettingsSummary { get; private set; }
         public List<ScannedWifiNetwork> WifiNetworks { get; private set; }
         public WifiConnectionStatus WifiConnectionStatus { get; private set; }
-        public StreamingCodeStatus StreamingCodeStatus { get; private set; }
+        public CastingCodeStatus CastingCodeStatus { get; private set; }
 
         public event Action<bool> OnAvailabilityChange;
         public event Action<DeviceData> OnDeviceDataChange;
@@ -75,7 +75,7 @@ namespace MXR.SDK {
         public event Action<PlayVideoCommandData> OnPlayVideoCommand;
         public event Action<PauseVideoCommandData> OnPauseVideoCommand;
         public event Action<ResumeVideoCommandData> OnResumeVideoCommand;
-        public event Action<StreamingCodeStatus> OnStreamingCodeStatusChanged;
+        public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
         public event Action<LaunchMXRHomeScreenCommandData> OnLaunchMXRHomeScreenCommand;
         public event Action OnHomeScreenStateRequest;
 
@@ -380,23 +380,23 @@ namespace MXR.SDK {
             }
         }
 
-        public void RequestStreamingCode() {
+        public void RequestCastingCode() {
             if (_messenger.IsBoundToService) {
-                LogIfEnabled(LogType.Log, "RequestStreamingCode called. Invoking over JNI: requestStreamingCodeAsync");
-                _messenger.Call<bool>("requestStreamingCodeAsync");
+                LogIfEnabled(LogType.Log, "RequestCastingCode called. Invoking over JNI: requestCastingCodeAsync");
+                _messenger.Call<bool>("requestCastingCodeAsync");
             } else {
                 LogIfEnabled(LogType.Warning,
-                    "RequestStreamingCode ignored. System is not available (not bound to messenger.");
+                    "RequestCastingCode ignored. System is not available (not bound to messenger.");
             }
         }
 
-        public void StopStreaming() {
+        public void StopCasting() {
             if (_messenger.IsBoundToService) {
-                LogIfEnabled(LogType.Log, "StopStreaming called. Invoking over JNI: stopStreamingAsync");
-                _messenger.Call<bool>("stopStreamingAsync");
+                LogIfEnabled(LogType.Log, "StopCasting called. Invoking over JNI: stopCastingAsync");
+                _messenger.Call<bool>("stopCastingAsync");
             } else {
                 LogIfEnabled(LogType.Warning,
-                    "StopStreaming ignored. System is not available (not bound to messenger.");
+                    "StopCasting ignored. System is not available (not bound to messenger.");
             }
         }
 

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -149,7 +149,7 @@ namespace MXR.SDK {
         public RuntimeSettingsSummary RuntimeSettingsSummary { get; private set; }
         public WifiConnectionStatus WifiConnectionStatus { get; private set; }
         public List<ScannedWifiNetwork> WifiNetworks { get; private set; }
-        public StreamingCodeStatus StreamingCodeStatus { get; private set; }
+        public CastingCodeStatus CastingCodeStatus { get; private set; }
 
         // INTERFACE EVENTS
         public event Action<bool> OnAvailabilityChange;
@@ -162,7 +162,7 @@ namespace MXR.SDK {
         public event Action<PlayVideoCommandData> OnPlayVideoCommand;
         public event Action<PauseVideoCommandData> OnPauseVideoCommand;
         public event Action<ResumeVideoCommandData> OnResumeVideoCommand;
-        public event Action<StreamingCodeStatus> OnStreamingCodeStatusChanged;
+        public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
         public event Action OnHomeScreenStateRequest;
 
         // INTERFACE METHODS
@@ -439,14 +439,14 @@ namespace MXR.SDK {
                 Debug.unityLogger.Log(LogType.Log, TAG, "Editor mode doesn't support ExitLauncher(). Safely ignored...");
         }
 
-        public void RequestStreamingCode() {
+        public void RequestCastingCode() {
             var expireAt = DateTimeOffset.UtcNow.AddMinutes(1.5).ToUnixTimeMilliseconds();
             var code = UnityEngine.Random.Range(100000, 999999).ToString();
-            StreamingCodeStatus = new StreamingCodeStatus(){code = code, errorMessage = "", expireAt = expireAt};
-            OnStreamingCodeStatusChanged?.Invoke(StreamingCodeStatus);
+            CastingCodeStatus = new CastingCodeStatus(){code = code, errorMessage = "", expireAt = expireAt};
+            OnCastingCodeStatusChanged?.Invoke(CastingCodeStatus);
         }
 
-        public void StopStreaming() {
+        public void StopCasting() {
             // No-op
         }
 

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -62,9 +62,9 @@ namespace MXR.SDK {
         ScannedWifiNetwork CurrentNetwork { get; }
         
         /// <summary>
-        /// The current status of a Streaming Code request.
+        /// The current status of a Casting Code request.
         /// </summary>
-        public StreamingCodeStatus StreamingCodeStatus { get; }
+        public CastingCodeStatus CastingCodeStatus { get; }
         
         /// <summary>
         /// Fired when the availability of system changes.
@@ -117,10 +117,10 @@ namespace MXR.SDK {
         event Action<ResumeVideoCommandData> OnResumeVideoCommand;        
         
         /// <summary>
-        /// Event fired when the streaming code status updates.
+        /// Event fired when the casting code status updates.
         /// This could be either a valid code, or an error message.
         /// </summary>
-        public event Action<StreamingCodeStatus> OnStreamingCodeStatusChanged;
+        public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
 
 
         /// <summary>
@@ -248,16 +248,15 @@ namespace MXR.SDK {
         /// </summary>
         void ExitLauncher();
 
+        /// <summary>
+        /// Makes a request to the Admin App for a Casting Code.
+        /// A response will be received via the <see cref="OnCastingCodeStatusChanged"/> event.
+        /// </summary>
+        void RequestCastingCode();
 
         /// <summary>
-        /// Makes a request to the Admin App for a Streaming Code.
-        /// A response will be received via the <see cref="OnStreamingCodeStatusChanged"/> event.
+        /// Stops a currently active casting session.
         /// </summary>
-        void RequestStreamingCode();
-
-        /// <summary>
-        /// Stops a currently active stream.
-        /// </summary>
-        void StopStreaming();
+        void StopCasting();
     }
 }

--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -304,7 +304,7 @@ namespace MXR.SDK {
     }
 
     [Serializable]
-    public class StreamingCodeStatus {
+    public class CastingCodeStatus {
         public string code;
         public long expireAt;
         public string errorMessage;


### PR DESCRIPTION
### TL;DR

Renamed all "streaming" terminology to "casting" throughout the SDK to better reflect the functionality.

### What changed?

- Renamed message types `GET_STREAMING_CODE` to `GET_CASTING_CODE` and `STOP_STREAMING` to `STOP_CASTING`
- Renamed constant `STREAMING_CODE` to `CASTING_CODE`
- Updated method names in `AdminAppMessengerManager.java`:
    - `requestStreamingCodeAsync()` → `requestCastingCodeAsync()`
    - `stopStreamingAsync()` → `stopCastingAsync()`
- Updated handler methods in `MXRAndroidSystem.Messages.cs`:
    - `HandleStreamingCode()` → `HandleCastingCode()`
- Renamed class `StreamingCodeStatus` to `CastingCodeStatus`
- Updated all related properties, methods, and event handlers in `MXRAndroidSystem.cs`, `MXREditorSystem.cs`, and `IMXRSystem.cs`