### PR TITLE
Version bump to 1.0.39

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.38",
+	"version": "1.0.39",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Bumped the ManageXR Unity SDK version from 1.0.38 to 1.0.39.

### What changed?

Updated the package version in `Assets/MXR.SDK/package.json` from 1.0.38 to 1.0.39.

