### PR TITLE
Add Try-Catch Safety

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
+++ b/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
@@ -8,6 +8,8 @@ namespace MXR.SDK {
     /// between Unity and the ManageXR Android Admin App.
     /// </summary>
     public class AdminAppMessengerManager {
+        private const string TAG = nameof(AdminAppMessengerManager);
+        
         /// <summary>
         /// Whether the instance is bound to the native service
         /// </summary>
@@ -126,7 +128,12 @@ namespace MXR.SDK {
             /// <param name="what">The message type</param>
             /// <param name="json">Message data</param>
             public void onMessageFromAdminApp(int what, string json) {
-                messenger.OnMessageFromAdminApp?.Invoke(what, json);
+                try {
+                    messenger.OnMessageFromAdminApp?.Invoke(what, json);
+                } catch (Exception ex) {
+                    Debug.unityLogger.LogError(TAG, 
+                        $"Exception in onMessageFromAdminApp (messageType: {what}): {ex.GetType().Name}: {ex.Message}\nStackTrace: {ex.StackTrace}");
+                }
             }
         }
     }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
@@ -26,8 +27,12 @@ namespace MXR.SDK {
         }
 
         private void OnMessageFromAdminApp(int what, string json) {
-            json = UnescapeJsonIfNeeded(json);
+            if (string.IsNullOrEmpty(json)) {
+                LogIfEnabled(LogType.Warning, $"Received null or empty JSON for message type {what}");
+                return;
+            }
 
+            json = UnescapeJsonIfNeeded(json);
             switch (what) {
                 case AdminAppMessageTypes.WIFI_NETWORKS:
                     HandleWifiNetworks(json);
@@ -51,106 +56,151 @@ namespace MXR.SDK {
                     ProcessCommandJson(json);
                     break;
                 case AdminAppMessageTypes.GET_HOME_SCREEN_STATE:
-                    OnHomeScreenStateRequest?.Invoke();
+                    try {
+                        OnHomeScreenStateRequest?.Invoke();
+                    } catch (Exception ex) {
+                        LogIfEnabled(LogType.Error, $"Exception in OnHomeScreenStateRequest event: {ex.GetType().Name}: {ex.Message}");
+                    }
+                    break;
+                default:
+                    LogIfEnabled(LogType.Warning, $"Unknown message type received: {what}");
                     break;
             }
         }
 
         private void HandleWifiNetworks(string json) {
-            if (json.Equals(lastWifiNetworksJSON)) {
-                return;
-            }
+            try {
+                if (json.Equals(lastWifiNetworksJSON)) {
+                    return;
+                }
 
-            var networks = JsonConvert.DeserializeObject<List<ScannedWifiNetwork>>(json);
-            if (networks == null) {
-                return;
-            }
+                var networks = JsonConvert.DeserializeObject<List<ScannedWifiNetwork>>(json);
+                if (networks == null) {
+                    LogIfEnabled(LogType.Warning, "Failed to deserialize WifiNetworks: result was null");
+                    return;
+                }
 
-            lastDeviceStatusJSON = json;
-            WifiNetworks = networks;
-            OnWifiNetworksChange?.Invoke(networks);
-            LogIfEnabled(LogType.Log, "WifiNetworks updated with " + WifiNetworks.Count + " networks.");
+                lastWifiNetworksJSON = json;
+                WifiNetworks = networks;
+                OnWifiNetworksChange?.Invoke(networks);
+                LogIfEnabled(LogType.Log, "WifiNetworks updated with " + WifiNetworks.Count + " networks.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleWifiNetworks: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleWifiNetworks: {ex.GetType().Name}: {ex.Message}");
+            }
         }
 
         private void HandleWifiConnectionStatus(string json) {
-            if (json.Equals(lastWifiConnectionStatusJSON)) {
-                return;
-            }
+            try {
+                if (json.Equals(lastWifiConnectionStatusJSON)) {
+                    return;
+                }
 
-            var status = JsonConvert.DeserializeObject<WifiConnectionStatus>(json);
-            if (status == null) {
-                return;
-            }
+                var status = JsonConvert.DeserializeObject<WifiConnectionStatus>(json);
+                if (status == null) {
+                    LogIfEnabled(LogType.Warning, "Failed to deserialize WifiConnectionStatus: result was null");
+                    return;
+                }
 
-            lastWifiConnectionStatusJSON = json;
-            WifiConnectionStatus = status;
-            OnWifiConnectionStatusChange?.Invoke(status);
-            LogIfEnabled(LogType.Log, "WifiConnectionStatus updated.");
+                lastWifiConnectionStatusJSON = json;
+                WifiConnectionStatus = status;
+                OnWifiConnectionStatusChange?.Invoke(status);
+                LogIfEnabled(LogType.Log, "WifiConnectionStatus updated.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleWifiConnectionStatus: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleWifiConnectionStatus: {ex.GetType().Name}: {ex.Message}");
+            }
         }
 
         private void HandleRuntimeSettingsSummary(string json) {
-            if (json.Equals(lastRuntimeSettingsSummaryJSON)) {
-                return;
+            try {
+                if (json.Equals(lastRuntimeSettingsSummaryJSON)) {
+                    return;
+                }
+
+                File.WriteAllText(_cachedRuntimeSettingsSummaryPath, json);
+                var summary = JsonConvert.DeserializeObject<RuntimeSettingsSummary>(json);
+                if (summary == null) {
+                    LogIfEnabled(LogType.Warning, "Failed to deserialize RuntimeSettingsSummary: result was null");
+                    return;
+                }
+
+                lastRuntimeSettingsSummaryJSON = json;
+                RuntimeSettingsSummary = summary;
+                OnRuntimeSettingsSummaryChange?.Invoke(summary);
+                LogIfEnabled(LogType.Log, "RuntimeSettingsSummary updated.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleRuntimeSettingsSummary: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleRuntimeSettingsSummary: {ex.GetType().Name}: {ex.Message}");
             }
-
-            File.WriteAllText(_cachedRuntimeSettingsSummaryPath, json);
-
-            var summary = JsonConvert.DeserializeObject<RuntimeSettingsSummary>(json);
-            if (summary == null) {
-                return;
-            }
-
-            lastRuntimeSettingsSummaryJSON = json;
-            RuntimeSettingsSummary = summary;
-            OnRuntimeSettingsSummaryChange?.Invoke(summary);
-            LogIfEnabled(LogType.Log, "RuntimeSettingsSummary updated.");
         }
 
         private void HandleDeviceStatus(string json) {
-            if (json.Equals(lastDeviceStatusJSON)) {
-                return;
+            try {
+                if (json.Equals(lastDeviceStatusJSON)) {
+                    return;
+                }
+
+                File.WriteAllText(_cachedDeviceStatusPath, json);
+                var status = JsonConvert.DeserializeObject<DeviceStatus>(json);
+                if (status == null) {
+                    LogIfEnabled(LogType.Warning, "Failed to deserialize DeviceStatus: result was null");
+                    return;
+                }
+
+                lastDeviceStatusJSON = json;
+                DeviceStatus = status;
+                OnDeviceStatusChange?.Invoke(status);
+                LogIfEnabled(LogType.Log, "DeviceStatus updated.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleDeviceStatus: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleDeviceStatus: {ex.GetType().Name}: {ex.Message}");
             }
-
-            File.WriteAllText(_cachedDeviceStatusPath, json);
-
-            var status = JsonConvert.DeserializeObject<DeviceStatus>(json);
-            if (status == null) {
-                return;
-            }
-
-            lastDeviceStatusJSON = json;
-            DeviceStatus = status;
-            OnDeviceStatusChange?.Invoke(status);
-            LogIfEnabled(LogType.Log, "DeviceStatus updated.");
         }
 
         private void HandleDeviceData(string json) {
-            if (json.Equals(lastDeviceDataJSON)) {
-                return;
+            try {
+                if (json.Equals(lastDeviceDataJSON)) {
+                    return;
+                }
+
+                File.WriteAllText(_cachedDeviceDataPath, json);
+
+                var data = JsonConvert.DeserializeObject<DeviceData>(json);
+                if (data == null) {
+                    return;
+                }
+
+                lastDeviceDataJSON = json;
+                DeviceData = data;
+                OnDeviceDataChange?.Invoke(data);
+                LogIfEnabled(LogType.Log, "DeviceData updated.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleDeviceData: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleDeviceData: {ex.GetType().Name}: {ex.Message}");
             }
-
-            File.WriteAllText(_cachedDeviceDataPath, json);
-
-            var data = JsonConvert.DeserializeObject<DeviceData>(json);
-            if (data == null) {
-                return;
-            }
-
-            lastDeviceDataJSON = json;
-            DeviceData = data;
-            OnDeviceDataChange?.Invoke(data);
-            LogIfEnabled(LogType.Log, "DeviceData updated.");
         }
 
         private void HandleCastingCode(string json) {
-            var castingCodeData = JsonConvert.DeserializeObject<CastingCodeStatus>(json);
-            if (castingCodeData == null) {
-                return;
-            }
+            try {
+                var castingCodeData = JsonConvert.DeserializeObject<CastingCodeStatus>(json);
+                if (castingCodeData == null) {
+                    return;
+                }
 
-            CastingCodeStatus = castingCodeData;
-            OnCastingCodeStatusChanged?.Invoke(castingCodeData);
-            LogIfEnabled(LogType.Log, "CastingCodeStatus updated.");
+                CastingCodeStatus = castingCodeData;
+                OnCastingCodeStatusChanged?.Invoke(castingCodeData);
+                LogIfEnabled(LogType.Log, "CastingCodeStatus updated.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleCastingCode: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleCastingCode: {ex.GetType().Name}: {ex.Message}");
+            }
         }
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -141,15 +141,21 @@ namespace MXR.SDK {
         /// Ref: https://stackoverflow.com/a/26406504
         /// </summary>
         private static string UnescapeJsonIfNeeded(string json) {
-            if (!json.StartsWith("\"")) {
+            try {
+                if (string.IsNullOrEmpty(json) || !json.StartsWith("\"")) {
+                    return json;
+                }
+
+                var token = JToken.Parse(json);
+                var obj = JObject.Parse((string)token);
+                json = obj.ToString();
+
+                return json;
+            } catch (Exception ex) {
+                Debug.unityLogger.LogError("MXRAndroidSystem",
+                    $"Failed to unescape JSON: {ex.GetType().Name}: {ex.Message}. Returning original JSON.");
                 return json;
             }
-
-            var token = JToken.Parse(json);
-            var obj = JObject.Parse((string)token);
-            json = obj.ToString();
-
-            return json;
         }
 
         private void LogIfEnabled(LogType logType, string message) {


### PR DESCRIPTION
### TL;DR

Improved error handling and logging in the MXR SDK Android communication layer.

### What changed?

- Added robust exception handling around message processing in `AdminAppMessengerManager` and `MXRAndroidSystem.Messages`
- Added detailed error logging for JSON deserialization failures and other exceptions
- Added null/empty checks for JSON data before processing
- Added handling for unknown message types
- Fixed a bug in `HandleWifiNetworks` where the wrong variable was being updated
- Added a constant TAG for consistent logging in `AdminAppMessengerManager`
- Improved the `UnescapeJsonIfNeeded` method with better error handling and null checks

