### PR TITLE
CU-868fmnk6b upload device logs bridge

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
@@ -54,4 +54,6 @@ public class AdminAppMessageTypes {
     public static final int CASTING_CODE = 21000;
     
     public static final int STOP_CASTING = 22;
+    
+    public static final int UPLOAD_DEVICE_LOGS = 23;
 }

--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -211,6 +211,10 @@ public class AdminAppMessengerManager {
     public boolean stopCastingAsync() {
         return sendMessage(AdminAppMessageTypes.STOP_CASTING);
     }
+    
+    public boolean uploadDeviceLogsAsync() {
+        return sendMessage(AdminAppMessageTypes.UPLOAD_DEVICE_LOGS);
+    }
 
     public boolean sendMessage(int what) {
         return sendMessage(what, null);

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -412,7 +412,7 @@ namespace MXR.SDK {
                 _messenger.Call<bool>("uploadDeviceLogsAsync");
             } else {
                 LogIfEnabled(LogType.Warning,
-                    "UploadDeviceLogs ignored. System is not available (not bound to messenger.");
+                    "UploadDeviceLogs ignored. System is not available (not bound to messenger.)");
             }
         }
 

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -406,6 +406,16 @@ namespace MXR.SDK {
             }
         }
 
+        public void UploadDeviceLogs() {
+            if (_messenger.IsBoundToService) {
+                LogIfEnabled(LogType.Log, "UploadDeviceLogs called. Invoking over JNI: uploadDeviceLogsAsync");
+                _messenger.Call<bool>("uploadDeviceLogsAsync");
+            } else {
+                LogIfEnabled(LogType.Warning,
+                    "UploadDeviceLogs ignored. System is not available (not bound to messenger.");
+            }
+        }
+
         /// <summary>
         /// Returns whether the SDK can read external files, taking into account
         /// whether we need any permissions for it or not.

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -200,7 +200,8 @@ namespace MXR.SDK {
 
         public void UploadDeviceLogs()
         { 
-            Debug.unityLogger.Log(LogType.Log, TAG, "Upload Device logs invoked, ignoring in editor");
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Log, TAG, "Upload Device logs invoked, ignoring in editor");
             //send logs
         }
 

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -198,7 +198,14 @@ namespace MXR.SDK {
             }
         }
 
-        public void OverrideKioskApp(string packageName) {
+        public void UploadDeviceLogs()
+        { 
+            Debug.unityLogger.Log(LogType.Log, TAG, "Upload Device logs involked, ignoring in editor");
+            //send logs
+        }
+
+        public void OverrideKioskApp(string packageName)
+        {
             if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Log, TAG, "Kiosk App set");
         }

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -200,7 +200,7 @@ namespace MXR.SDK {
 
         public void UploadDeviceLogs()
         { 
-            Debug.unityLogger.Log(LogType.Log, TAG, "Upload Device logs involked, ignoring in editor");
+            Debug.unityLogger.Log(LogType.Log, TAG, "Upload Device logs invoked, ignoring in editor");
             //send logs
         }
 

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -6,7 +6,8 @@ namespace MXR.SDK {
     /// Exposes properties, events and methods to the ManageXR 
     /// admin/system application
     /// </summary>
-    public interface IMXRSystem {
+    public interface IMXRSystem
+    {
         /// <summary>
         /// Whether the system will log messages to the Unity console
         /// </summary>
@@ -60,12 +61,12 @@ namespace MXR.SDK {
         /// WiFi network currently connected to (if any)
         /// </summary>
         ScannedWifiNetwork CurrentNetwork { get; }
-        
+
         /// <summary>
         /// The current status of a Casting Code request.
         /// </summary>
         CastingCodeStatus CastingCodeStatus { get; }
-        
+
         /// <summary>
         /// Fired when the availability of system changes.
         /// </summary>
@@ -100,7 +101,7 @@ namespace MXR.SDK {
         /// Event fired when a Launch App command is received, specific to the MXR Home Screen.
         /// </summary>
         event Action<LaunchMXRHomeScreenCommandData> OnLaunchMXRHomeScreenCommand;
-        
+
         /// <summary>
         /// Event fired when a Play Video command is received
         /// </summary>
@@ -114,8 +115,8 @@ namespace MXR.SDK {
         /// <summary>
         /// Event fired when a Resume Video command is received
         /// </summary>
-        event Action<ResumeVideoCommandData> OnResumeVideoCommand;        
-        
+        event Action<ResumeVideoCommandData> OnResumeVideoCommand;
+
         /// <summary>
         /// Event fired when the casting code status updates.
         /// This could be either a valid code, or an error message.
@@ -157,7 +158,7 @@ namespace MXR.SDK {
         /// Powers off the device.
         /// </summary>
         void Shutdown();
-        
+
         /// <summary>
         /// Restarts the device.
         /// </summary>
@@ -257,5 +258,7 @@ namespace MXR.SDK {
         /// Stops a currently active casting session.
         /// </summary>
         void StopCasting();
+
+        void UploadDeviceLogs();
     }
 }

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -6,8 +6,7 @@ namespace MXR.SDK {
     /// Exposes properties, events and methods to the ManageXR 
     /// admin/system application
     /// </summary>
-    public interface IMXRSystem
-    {
+    public interface IMXRSystem {
         /// <summary>
         /// Whether the system will log messages to the Unity console
         /// </summary>
@@ -259,6 +258,9 @@ namespace MXR.SDK {
         /// </summary>
         void StopCasting();
 
+        /// <summary>
+        /// Sends logs from the headset to the web console.
+        /// </summary>
         void UploadDeviceLogs();
     }
 }

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.41",
+	"version": "1.0.42",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Added device log upload functionality to the Android admin app messenger system.

### What changed?

- Added a new message type `UPLOAD_DEVICE_LOGS` (value 23) in `AdminAppMessageTypes.java`
- Implemented a new method `uploadDeviceLogsAsync()` in `AdminAppMessengerManager.java` that sends the new message type
- Added a corresponding `UploadDeviceLogs()` method in `MXRAndroidSystem.cs` that calls the Java implementation through JNI


### Why make this change?

This change enables remote collection of device logs through the admin app, which will help with debugging and troubleshooting issues on deployed devices without requiring physical access to the hardware.