### PR TITLE
Unity 6 compatibility

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
+++ b/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
@@ -4,21 +4,15 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.util.Log;
-import android.os.Bundle;
-import android.os.Build;
 import android.app.ActivityManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.Canvas;
 
-import com.unity3d.player.UnityPlayer;
-import com.unity3d.player.UnityPlayerActivity;
 import java.util.*;
 import java.io.ByteArrayOutputStream;
-import android.util.TimingLogger;
 import android.util.Log;
 import android.net.Uri;
 

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.42",
+	"version": "1.0.43",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
NativeUtils.java was importing UnityPlayerActivity which has been removed. Since it's not used anyway, it along with other unused namespaces have been removed.