### PR TITLE
CU-868g5cm0m: Fix Compile Error

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
+++ b/Assets/MXR.SDK/Runtime/Android/AdminAppMessengerManager.cs
@@ -116,7 +116,7 @@ namespace MXR.SDK {
             /// <param name="bound">New bound status</param>
             public void onBindStatusToAdminAppChanged(bool bound) {
                 // Dispatch to Unity main thread since this is called from Android main thread
-                Dispatcher.RunOnMainThread(0) => {
+                Dispatcher.RunOnMainThread(() => {
                     if (messenger.IsBoundToService != bound) {
                         Debug.unityLogger.Log(LogType.Log, "AdminAppMessengerManager bind state changed to: " + bound);
                         messenger.IsBoundToService = bound;
@@ -132,7 +132,7 @@ namespace MXR.SDK {
             /// <param name="json">Message data</param>
             public void onMessageFromAdminApp(int what, string json) {
                 // Dispatch to Unity main thread since this is called from Android main thread
-                Dispatcher.RunOnMainThread(0) => {
+                Dispatcher.RunOnMainThread(() => {
                     try {
                         messenger.OnMessageFromAdminApp?.Invoke(what, json);
                     } catch (Exception ex) {

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.43",
+	"version": "1.0.44",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Fixed syntax errors in the AdminAppMessengerManager's callback methods.

### What changed?

- Fixed two syntax errors in the `AdminAppMessengerManager.cs` file where lambda expressions were incorrectly defined with `0) =>` instead of `() =>`
- Incremented the package version from 1.0.43 to 1.0.44 in `package.json`​



Closes #205