### PR TITLE
CU-868g6mr5m: Notif Of Termination Event

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
@@ -56,4 +56,6 @@ public class AdminAppMessageTypes {
     public static final int STOP_CASTING = 22;
     
     public static final int UPLOAD_DEVICE_LOGS = 23;
+    
+    public static final int PREPARE_FOR_TERMINATION = 24000;
 }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -24,6 +24,7 @@ namespace MXR.SDK {
             public const int HANDLE_COMMAND = 6000;
             public const int GET_HOME_SCREEN_STATE = 15000;
             public const int CASTING_CODE = 21000;
+            public const int PREPARE_FOR_TERMINATION = 24000;
         }
 
         private void OnMessageFromAdminApp(int what, string json) {
@@ -60,6 +61,14 @@ namespace MXR.SDK {
                         OnHomeScreenStateRequest?.Invoke();
                     } catch (Exception ex) {
                         LogIfEnabled(LogType.Error, $"Exception in OnHomeScreenStateRequest event: {ex.GetType().Name}: {ex.Message}");
+                    }
+                    break;
+                case AdminAppMessageTypes.PREPARE_FOR_TERMINATION:
+                    LogIfEnabled(LogType.Log, $"Termination Notification Received");
+                    try {
+                        OnTerminationNotification?.Invoke();
+                    } catch (Exception ex) {
+                        LogIfEnabled(LogType.Error, $"Exception in OnTerminationNotificatiocln event: {ex.GetType().Name}: {ex.Message}");
                     }
                     break;
                 default:
@@ -202,5 +211,6 @@ namespace MXR.SDK {
                 LogIfEnabled(LogType.Error, $"Unexpected error in HandleCastingCode: {ex.GetType().Name}: {ex.Message}");
             }
         }
+
     }
 }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -78,6 +78,7 @@ namespace MXR.SDK {
         public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
         public event Action<LaunchMXRHomeScreenCommandData> OnLaunchMXRHomeScreenCommand;
         public event Action OnHomeScreenStateRequest;
+        public event Action OnTerminationNotification;
 
         private string lastWifiNetworksJSON = string.Empty;
         private string lastWifiConnectionStatusJSON = string.Empty;

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -164,6 +164,7 @@ namespace MXR.SDK {
         public event Action<ResumeVideoCommandData> OnResumeVideoCommand;
         public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
         public event Action OnHomeScreenStateRequest;
+        public event Action OnTerminationNotification;
 
         // INTERFACE METHODS
         public void DisableKioskMode() {

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -127,6 +127,12 @@ namespace MXR.SDK {
         /// <see cref="HomeScreenState"/> 
         /// </summary>
         event Action OnHomeScreenStateRequest;
+        
+        /// <summary>
+        /// Event fired when the admin app is about to force close the application.
+        /// Use this to avoid hard crash notifications in error reporting.
+        /// </summary>
+        event Action OnTerminationNotification;
 
         /// <summary>
         /// Disable Kiosk mode on the device


### PR DESCRIPTION
### TL;DR

Added support for a new "prepare for termination" message from the admin app.

### What changed?

- Added a new message type constant `PREPARE_FOR_TERMINATION` with value `24000` in both Java and C# code
- Implemented a handler for this message in `OnMessageFromAdminApp` method
- Added a new event `OnTerminationNotification` that gets triggered when this message is received
- This allows applications to gracefully handle imminent termination by the admin app, avoiding hard crash notifications in error reporting