### PR TITLE
CU-868gk0906: Quest3s Device Type

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
@@ -216,7 +216,8 @@ namespace MXR.SDK {
         /// Returns true if the current device is Oculus Quest 3s
         /// </summary>
         public static bool IsQuest3S =>
-            Application.isEditor ? false : DeviceProduct.Equals("panther", StringComparison.OrdinalIgnoreCase);
+            !Application.isEditor && (DeviceProduct.Equals("panther", StringComparison.OrdinalIgnoreCase)
+                                      || DeviceProduct.Equals("onca", StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
         /// Returns true if the current device is Oculus Go

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.45",
+	"version": "1.0.46",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Added support for the "onca" device identifier for Quest 3S detection.

### What changed?

Updated the `IsQuest3S` property in `MXRAndroidUtils.Device.cs` to check for both "panther" and "onca" device product identifiers. The logic now uses an OR condition to match either identifier when determining if the current device is an Oculus Quest 3S.