### PR TITLE
ENG-109 stop resume from killing background app

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
+++ b/Assets/MXR.SDK/Plugins/Android/NativeUtils.java
@@ -68,6 +68,38 @@ public class NativeUtils {
         }
     }
 
+    public boolean resumeApp(String packageName) {
+        try {
+            Intent intent = mContext.getPackageManager().getLaunchIntentForPackage(packageName);
+            if (intent == null) {
+                return false;
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            mContext.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.e("NativeUtils", e.toString());
+            return false;
+        }
+    }
+
+    public boolean resumeAppWithClass(String packageName, String className) {
+        try {
+            if (!isAppInstalled(packageName)) {
+                return false;
+            }
+
+            Intent i = new Intent();
+            i.setClassName(packageName, className);
+            i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            mContext.startActivity(i);
+            return true;
+        } catch (Exception e) {
+            Log.e("NativeUtils", e.toString());
+            return false;
+        }
+    }
+
     public boolean launchOculusSystemUx(String dataUri) {
         try {
             Intent i = new Intent(Intent.ACTION_VIEW);

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Apps.cs
@@ -94,6 +94,19 @@ namespace MXR.SDK {
         public static void LaunchAppWithPackageAndClassNames(string packageName, string className) =>
             NativeUtils.SafeCall<bool>("launchAppWithClass", packageName, className);
 
+        public static void ResumeRuntimeApp(RuntimeApp app) {
+            if (string.IsNullOrEmpty(app.className))
+                ResumeAppWithPackageName(app.packageName);
+            else
+                ResumeAppWithPackageAndClassNames(app.packageName, app.className);
+        }
+
+        public static void ResumeAppWithPackageName(string packageName) =>
+            NativeUtils.SafeCall<bool>("resumeApp", packageName);
+
+        public static void ResumeAppWithPackageAndClassNames(string packageName, string className) =>
+            NativeUtils.SafeCall<bool>("resumeAppWithClass", packageName, className);
+
         public static void LaunchIntentAction(string intentAction) =>
             NativeUtils.SafeCall<bool>("launchIntentAction", intentAction);
 

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.46",
+	"version": "1.0.47",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Added new functionality to resume Android apps instead of just launching them.

### What changed?

- Added two new Java methods in `NativeUtils.java`:
  - `resumeApp(String packageName)` - Resumes an app using its package name
  - `resumeAppWithClass(String packageName, String className)` - Resumes an app using both package and class names

- Added corresponding C# wrapper methods in `MXRAndroidUtils.Apps.cs`:
  - `ResumeRuntimeApp(RuntimeApp app)`
  - `ResumeAppWithPackageName(string packageName)`
  - `ResumeAppWithPackageAndClassNames(string packageName, string className)`

### How to test?

1. Build the SDK for an Android device
2. Test resuming apps that are already running in the background using the new methods
3. Verify that apps are brought to the foreground without restarting

### Why make this change?

This change allows for more efficient app switching by resuming existing app instances rather than launching new ones. The resume functionality uses Android intent flags like `FLAG_ACTIVITY_REORDER_TO_FRONT` and `FLAG_ACTIVITY_SINGLE_TOP` to bring existing app instances to the foreground, preserving their state and avoiding the overhead of restarting them.