### PR TITLE
ENG-1696: Fix UNKNOWN enum values to use -1 to preserve serialized integer mappings

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/ContentTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/ContentTypes.cs
@@ -182,7 +182,7 @@ namespace MXR.SDK {
 
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum VideoType {
-            UNKNOWN,
+            UNKNOWN = -1,
             _360,
             _180,
             _2D,
@@ -197,7 +197,7 @@ namespace MXR.SDK {
 
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum VideoDisplay {
-            UNKNOWN,
+            UNKNOWN = -1,
             MONO,
             STEREO,
         }

--- a/Assets/MXR.SDK/Runtime/Types/HomeScreenTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/HomeScreenTypes.cs
@@ -29,7 +29,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum HomeScreenView {
-        UNKNOWN,
+        UNKNOWN = -1,
         LIBRARY,
         VIDEO_PLAYER,
         WIFI,
@@ -78,7 +78,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum HomeScreenVideoState {
-        UNKNOWN,
+        UNKNOWN = -1,
 
         /// <summary>
         /// Whether a video is currently playing

--- a/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/RuntimeTypes.cs
@@ -247,7 +247,7 @@ namespace MXR.SDK {
         [Serializable]
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum DisplayLanguage {
-            UNKNOWN,
+            UNKNOWN = -1,
             enUS,
             frFR,
             deDE,
@@ -376,7 +376,7 @@ namespace MXR.SDK {
     /// </summary>
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum EnvironmentFileType {
-        UNKNOWN,
+        UNKNOWN = -1,
 
         /// <summary>
         /// The ManageXR .mxrus file based on AssetBundle
@@ -523,7 +523,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum VerticalCardAlignment {
-        UNKNOWN,
+        UNKNOWN = -1,
         TOP,
         CENTER,
         BOTTOM
@@ -532,7 +532,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum HorizontalCardAlignment {
-        UNKNOWN,
+        UNKNOWN = -1,
         LEFT,
         CENTER,
         RIGHT
@@ -542,7 +542,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum CardStyle {
-        UNKNOWN,
+        UNKNOWN = -1,
         PADDING,
         NO_PADDING,
         NO_BACKGROUND
@@ -551,7 +551,7 @@ namespace MXR.SDK {
     [Serializable]
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum HorizontalTextAlignment  {
-        UNKNOWN,
+        UNKNOWN = -1,
         LEFT,
         CENTER,
         RIGHT

--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -181,13 +181,13 @@ namespace MXR.SDK {
         [System.Serializable]
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum Status {
-            UNKNOWN, QUEUED, DOWNLOADING, COMPLETE, ERROR
+            UNKNOWN = -1, QUEUED, DOWNLOADING, COMPLETE, ERROR
         }
 
         [System.Serializable]
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum ManagedFileType {
-            UNKNOWN, FILE, ICON, BRANDING, VIDEO, ENVIRONMENT
+            UNKNOWN = -1, FILE, ICON, BRANDING, VIDEO, ENVIRONMENT
         }
 
         public Status status;
@@ -225,7 +225,7 @@ namespace MXR.SDK {
     public class AppInstallStatus {
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum Status {
-            UNKNOWN,
+            UNKNOWN = -1,
             QUEUED,
             SETUP,
             DOWNLOADING,
@@ -239,7 +239,7 @@ namespace MXR.SDK {
         }
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum InstallMethod {
-            UNKNOWN,
+            UNKNOWN = -1,
             PATCH_INSTALL,
             FULL_INSTALL,
             FORCE_INSTALL
@@ -289,7 +289,7 @@ namespace MXR.SDK {
     public class DeviceSystemVersionInstallStatus {
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum Status {
-            UNKNOWN,
+            UNKNOWN = -1,
             UP_TO_DATE,
             DOWNLOADING,
             READY_TO_INSTALL,
@@ -327,7 +327,7 @@ namespace MXR.SDK {
     public class ScreenCast {
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum Type {
-            UNKNOWN,
+            UNKNOWN = -1,
             NATIVE,
             WEB_CONSOLE,
             CODE_BASED
@@ -335,7 +335,7 @@ namespace MXR.SDK {
 
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         public enum State {
-            UNKNOWN,
+            UNKNOWN = -1,
             INITIATED,
             REQUESTING_PERMS,
             CANCELLED,

--- a/Assets/MXR.SDK/Runtime/Types/TolerantStringEnumConverter.cs
+++ b/Assets/MXR.SDK/Runtime/Types/TolerantStringEnumConverter.cs
@@ -10,7 +10,7 @@ namespace MXR.SDK {
     /// <summary>
     /// A JSON converter for enums that gracefully handles unknown values instead of throwing.
     /// When an unrecognized string value is encountered during deserialization, it defaults to
-    /// the enum's 0-value (typically UNKNOWN) and logs a warning.
+    /// the UNKNOWN member (value -1) and logs a warning.
     /// This provides forward-compatibility when the API introduces new enum values that
     /// older SDK builds don't have.
     /// </summary>
@@ -26,7 +26,7 @@ namespace MXR.SDK {
                 return base.ReadJson(reader, objectType, existingValue, serializer);
             }
             catch (JsonSerializationException) {
-                var fallback = Enum.ToObject(enumType, 0);
+                var fallback = Enum.ToObject(enumType, -1);
                 Debug.LogWarning(
                     $"[MXR SDK] Unknown enum value '{reader.Value}' for type {enumType.Name}, defaulting to {fallback}");
                 return fallback;

--- a/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/WifiTypes.cs
@@ -14,7 +14,7 @@ namespace MXR.SDK {
         /// <summary>
         /// Unknown network type.
         /// </summary>
-        UNKNOWN,
+        UNKNOWN = -1,
 
         /// <summary>
         /// Does not require a password
@@ -71,7 +71,7 @@ namespace MXR.SDK {
             /// <summary>
             /// Unknown state from an unrecognized value.
             /// </summary>
-            UNKNOWN,
+            UNKNOWN = -1,
 
             /// <summary>
             /// Ready to start data connection setup.
@@ -309,7 +309,7 @@ namespace MXR.SDK {
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum EapMethod
     {
-        UNKNOWN,
+        UNKNOWN = -1,
         PEAP,
         TTLS,
         PWD,
@@ -318,7 +318,7 @@ namespace MXR.SDK {
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum Phase2Method
     {
-        UNKNOWN,
+        UNKNOWN = -1,
         PAP,
         MSCHAP,
         MSCHAPV2,
@@ -366,7 +366,7 @@ namespace MXR.SDK {
 
     [JsonConverter(typeof(TolerantStringEnumConverter))]
     public enum WifiAuthenticationError {
-        UNKNOWN,
+        UNKNOWN = -1,
         TIMEOUT,
         WRONG_PASSWORD,
         EAP_FAILURE,

--- a/Assets/MXR.SDK/Tests/Editor/TolerantStringEnumConverterTests.cs
+++ b/Assets/MXR.SDK/Tests/Editor/TolerantStringEnumConverterTests.cs
@@ -10,7 +10,7 @@ namespace MXR.SDK.Tests {
         // Test enum that uses the converter, mirroring the pattern in the SDK
         [JsonConverter(typeof(TolerantStringEnumConverter))]
         enum TestStatus {
-            UNKNOWN,
+            UNKNOWN = -1,
             ACTIVE,
             INACTIVE
         }


### PR DESCRIPTION
## Summary

- v1.0.52 added `UNKNOWN` as the first member (value 0) of every `TolerantStringEnumConverter`-backed enum, shifting all existing members by +1
- This broke C# default values (uninitialized fields resolve to `UNKNOWN` instead of the first real member like `PADDING`) and serialized integer mappings in downstream consumers (e.g. custom-launcher's `LayoutConstants.asset` stores `CardStyle` as int 0/1/2)
- Fix: set `UNKNOWN = -1` on all affected enums so existing members retain their original integer values, and update `TolerantStringEnumConverter` to fall back to `-1` instead of `0`

**Linear:** [ENG-1696](https://linear.app/managexr/issue/ENG-1696/app-icon-too-large-in-homescreen)

## Test plan

- [x] Verify custom-launcher `LayoutConstants.asset` integer mappings (style: 0, 1, 2) still resolve to `PADDING`, `NO_PADDING`, `NO_BACKGROUND`
- [x] Verify uninitialized `CardStyle` field defaults to `PADDING` (int 0), not `UNKNOWN`
- [x] Verify `TolerantStringEnumConverter` still returns `UNKNOWN` for unrecognized JSON enum strings
- [x] Deploy to Quest 3 and confirm library panel icons have correct padding/borders when `librarySettings` is absent from RSS