### PR TITLE
Retry pipeline slice 2: Mirror retry-state fields on C# status types

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -174,6 +174,26 @@ namespace MXR.SDK {
     }
 
     /// <summary>
+    /// Categorizes a download/install error to drive retry UX decisions.
+    /// Populated on <see cref="AppInstallStatus"/> and <see cref="FileInstallStatus"/>
+    /// when the status transitions to ERROR. UNKNOWN is the tolerant fallback for
+    /// categories the SDK doesn't yet recognize (forward-compat with newer admin apps).
+    /// </summary>
+    [System.Serializable]
+    [JsonConverter(typeof(TolerantStringEnumConverter))]
+    public enum ErrorCategory {
+        UNKNOWN = -1,
+        /// <summary>No error has been classified. Valid while the status is not ERROR.</summary>
+        NONE,
+        /// <summary>Retry is in flight or could still fire. Treat as recoverable.</summary>
+        TRANSIENT,
+        /// <summary>Automatic retry budget exhausted. A user-triggered retry may still succeed.</summary>
+        TERMINAL_RETRY_EXHAUSTED,
+        /// <summary>Non-retriable (bad URL, invalid checksum, etc.). Retry will not help.</summary>
+        TERMINAL_NO_RETRY
+    }
+
+    /// <summary>
     /// Represents the status of a file on the device
     /// </summary>
     [System.Serializable]
@@ -201,6 +221,12 @@ namespace MXR.SDK {
         public string message;
         public int errorCode;
         public ManagedFileType managedFileType;
+
+        // Retry state surfaced by the admin app for HS retry UX. Populated by a
+        // follow-up release; defaults here are safe placeholders.
+        public int retryCount;
+        public bool isRetrying;
+        public ErrorCategory errorCategory = ErrorCategory.NONE;
     }
 
     [System.Serializable]
@@ -258,6 +284,12 @@ namespace MXR.SDK {
         public int errorCode;
         public string message;
         public Timestamp timestamp = new Timestamp();
+
+        // Retry state surfaced by the admin app for HS retry UX. Populated by a
+        // follow-up release; defaults here are safe placeholders.
+        public int retryCount;
+        public bool isRetrying;
+        public ErrorCategory errorCategory = ErrorCategory.NONE;
 
         /// <summary>
         /// Whether we're currently in an update phase


### PR DESCRIPTION
## Summary

- Adds C# `ErrorCategory` enum (`UNKNOWN = -1`, `NONE`, `TRANSIENT`, `TERMINAL_RETRY_EXHAUSTED`, `TERMINAL_NO_RETRY`) in `StatusTypes.cs`, top-level in the `MXR.SDK` namespace
- Adds `retryCount` (int), `isRetrying` (bool), `errorCategory` (ErrorCategory) to `AppInstallStatus` and `FileInstallStatus`
- Defaults `0` / `false` / `ErrorCategory.NONE` — no behavior change, pure wire-shape mirror of the admin-app-side slice 1

## Linear

**ENG-TBD** — ticket to be filed once Linear MCP auth returns (Nic action). This is slice 2 of the retry pipeline spec (see `Projects/Retry Pipeline - Implementation Spec.md` in the Obsidian vault).

## Pairs with

- **Admin app slice 1:** ManageXR/mighty-admin-app#2385 (field additions on `AppInstallStatus` / `ManagedFileInstallStatus`)
- Together these define the wire contract. Neither side populates the new fields yet — slice 3 lands that.

## Design notes

- `ErrorCategory` uses `UNKNOWN = -1` as the first member, matching the pattern established by ENG-1696 (`TolerantStringEnumConverter` tolerant deserialization). An admin app that introduces a new category string in the future will deserialize to `UNKNOWN` on this SDK version rather than throwing.
- Kept the enum top-level in the `MXR.SDK` namespace rather than nesting it inside one of the status classes — both `AppInstallStatus` and `FileInstallStatus` reference the same type, and nesting would force a cross-class reference.
- Default value of `errorCategory` is `NONE` (= 0) so struct default-init on new instances lands on a valid sentinel. C# enum default is 0; `NONE` is at position 0 (`UNKNOWN = -1` is explicitly off-numbered). Explicit `= ErrorCategory.NONE` for readability.

## Test plan

- [ ] Unity compile succeeds in the consuming HS project (`custom-launcher`) against this SDK
- [ ] Deserialize a `DEVICE_STATUS` payload from an admin app with the slice-1 fields populated (e.g. `"retryCount": 3, "isRetrying": true, "errorCategory": "TRANSIENT"`); confirm fields round-trip
- [ ] Deserialize a payload without the new fields (older admin app); confirm defaults are `0` / `false` / `NONE` and no warnings are logged
- [ ] Deserialize a payload with an unknown `errorCategory` string; confirm tolerant converter maps to `UNKNOWN`

## Out of scope

- C# SDK wrappers (`IMXRSystem.RetryAppDownload` / `RetryAppDownloads`) — slice 6, Vatsal may own per Tue Apr 21 1:1
- Admin-app-side classification logic populating these fields — slice 3, blocked on Katie error-code sign-off
- IPC message plumbing — slices 4/5

## Notes

- No new `.cs` files added; only modifies `StatusTypes.cs`. No new `.meta` files needed.
- Version bump handled in a separate chore PR when this lands and is ready to release (Vatsal mentioned two planned SDK releases in order: `time_remaining` first, then retry methods — this mirror slice likely lands with the retry-methods release).
- Draft — not requesting review yet. Nic to review before promoting.