### PR TITLE
Add timeRemaining field in install status types

### DIFF
--- a/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/StatusTypes.cs
@@ -195,6 +195,7 @@ namespace MXR.SDK {
         public string path;
         public string name;
         public int progress;
+        public long timeRemaining;
         public long totalBytesDownloaded;
         public long totalDownloadSize;
         public Timestamp timestamp = new Timestamp();
@@ -249,6 +250,7 @@ namespace MXR.SDK {
         public InstallMethod installMethod;
         public string packageName;
         public long progress;
+        public long timeRemaining;
         public long totalBytesDownloaded;
         public long totalDownloadSize;
         public long currentVersion;

--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.53",
+	"version": "1.0.54",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
### TL;DR

Added `timeRemaining` field to both file and app download/install status types.

### What changed?

A `timeRemaining` field of type `long` has been added to the download progress tracking structs for managed files and app installations. This field sits alongside the existing `totalBytesDownloaded` and `totalDownloadSize` fields, providing an estimated time (in seconds) remaining during download operations.

### How to test?

Trigger a managed file download or app installation and verify that the `timeRemaining` field is populated and reflects a reasonable estimated time remaining during the download process.

### Why make this change?

Exposing `timeRemaining` allows applications to display estimated download completion times to users, improving the user experience during file and app download operations.