### PR TITLE
ENG-1887: Retry app downloads

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
@@ -58,4 +58,8 @@ public class AdminAppMessageTypes {
     public static final int UPLOAD_DEVICE_LOGS = 23;
     
     public static final int PREPARE_FOR_TERMINATION = 24000;
+
+    public static final int RETRY_APP_DOWNLOAD = 25;
+
+    public static final int RETRY_APP_DOWNLOADS = 26;
 }

--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -21,6 +21,8 @@ import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
 import android.util.Log;
+import java.util.List;
+import java.lang.StringBuilder;
 
 public class AdminAppMessengerManager {
     public interface  AdminAppMessengerListener {
@@ -154,6 +156,30 @@ public class AdminAppMessengerManager {
 
     public boolean killApp(String packageName) {
         return sendMessage(AdminAppMessageTypes.KILL_APP, "{\"packageName\":\""+packageName+"\"}");
+    }
+
+    public boolean retryAppDownload(String packageName) {
+        return sendMessage(AdminAppMessageTypes.RETRY_APP_DOWNLOAD, "{\"packageName\":\""+packageName+"\"}");
+    }
+
+    public boolean retryAppDownloads(List<String> packageNames) {
+        StringBuilder payload = new StringBuilder();
+        payload.append("{\"packageNames\":[");
+
+        for (int i = 0; i < packageNames.size(); i++) {
+            payload.append("\"").append(packageNames.get(i)).append("\"");
+
+            if (i < packageNames.size() - 1) {
+                payload.append(",");
+            }
+        }
+
+        payload.append("]}");
+
+        return sendMessage(
+            AdminAppMessageTypes.RETRY_APP_DOWNLOADS,
+            payload.toString()
+        );
     }
 
     public boolean restartApp(String packageName) {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -323,6 +325,31 @@ namespace MXR.SDK {
                 _messenger.Call<bool>("killApp", packageName);
             } else {
                 LogIfEnabled(LogType.Warning, "KillApp ignored. System is not available (not bound to messenger).");
+            }
+        }
+
+
+        public void RetryAppDownload(string packageName) {
+            packageName = EscapeStringToJsonString(packageName);
+
+            if (_messenger.IsBoundToService) {
+                LogIfEnabled(LogType.Log, "RetryAppDownload called. Invoking over JNI: retryAppDownload");
+                _messenger.Call<bool>("retryAppDownload", packageName);
+            }
+            else {
+                LogIfEnabled(LogType.Warning, "retryAppDownload ignored. System is not available (not bound to messenger).");
+            }
+        }
+
+        public void RetryAppDownloads(IEnumerable<string> packageNames) {
+            packageNames = packageNames.Select(x => EscapeStringToJsonString(x));
+
+            if (_messenger.IsBoundToService) {
+                LogIfEnabled(LogType.Log, "RetryAppDownloads called. Invoking over JNI: retryAppDownloads");
+                _messenger.Call<bool>("retryAppDownloads", packageNames);
+            }
+            else {
+                LogIfEnabled(LogType.Warning, "retryAppDownloads ignored. System is not available (not bound to messenger).");
             }
         }
 

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections;
 using System.Collections.Generic;
@@ -103,7 +103,7 @@ namespace MXR.SDK {
             set => loggingEnabled = value;
         }
 
-        public bool IsAdminAppInstalled => 
+        public bool IsAdminAppInstalled =>
             Directory.Exists(Path.Combine(MXRStorage.ExternalStorageDirectory, "MightyImmersion"));
 
         public bool IsConnectedToAdminApp => IsAvailable;
@@ -171,7 +171,7 @@ namespace MXR.SDK {
         public void DisableKioskMode() {
             try {
                 if (RuntimeSettingsSummary.kioskModeEnabled == false) return;
-                
+
                 RuntimeSettingsSummary.kioskModeEnabled = false;
                 WriteRuntimeSettings();
                 if (LoggingEnabled)
@@ -216,6 +216,16 @@ namespace MXR.SDK {
         public void KillApp(string packageName) {
             if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Log, TAG, "Killed App");
+        }
+
+        public void RetryAppDownload(string packageName) {
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Log, TAG, $"RetryAppDownload({packageName}) invoked, ignoring in editor");
+        }
+
+        public void RetryAppDownloads(IEnumerable<string> packageNames) {
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Log, TAG, $"RetryAppDownloads({string.Join(", ", packageNames)}) invoked, ignoring in editor");
         }
 
         public void RestartApp(string packageName) {

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -160,6 +160,18 @@ namespace MXR.SDK {
         void KillApp(string packageName);
 
         /// <summary>
+        /// Retry downloading and installing an app
+        /// </summary>
+        /// <param name="packageName">Package name of the app to retry </param>
+        void RetryAppDownload(string packageName);
+
+        /// <summary>
+        /// Retry multiple apps using package names
+        /// </summary>
+        /// <param name="packageNames">Package names of apps to retry</param>
+        void RetryAppDownloads(IEnumerable<string> packageNames);
+
+        /// <summary>
         /// Kills and then restarts the running application with packageName.
         /// </summary>
         void RestartApp(string packageName);


### PR DESCRIPTION
## Summary
Adds support for retrying app downloads via the Admin App messenger. Two new message types `RETRY_APP_DOWNLOAD` and `RETRY_APP_DOWNLOADS` are introduced, along with corresponding methods to retry a single app download by package name or multiple app downloads by a list of package names. 

The `IMXRSystem` interface is updated with the new `RetryAppDownload` and `RetryAppDownloads` methods, and both the Android and Editor system implementations provide the appropriate behavior.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other