### PR TITLE
Bump version to 1.0.55

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.54",
+	"version": "1.0.55",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
Version bump waiting on https://github.com/ManageXR/mxr-unity-sdk/pull/242 and https://github.com/ManageXR/mxr-unity-sdk/pull/240 for App Download Retry feature release