### PR TITLE
ENG-2254: add Pico Swan device detection and PUI compatibility to MXR Unity SDK

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRAndroidUtils.Device.cs
@@ -202,6 +202,23 @@ namespace MXR.SDK {
             }
         }
 
+        static readonly List<string> knownPicoSwanDeviceModels = new List<string> {
+            "B3110"
+        };
+        /// <summary>
+        /// Returns true if the current device is Pico Swan
+        /// </summary>
+        public static bool IsPicoSwan {
+            get {
+                if (Application.isEditor) return false;
+                // Mirrors mighty-admin-app PicoModel.SWAN_MODELS / SWAN_PRODUCTS:
+                //   Build.MODEL    = "B3110"
+                //   Build.PRODUCT  = "swan"
+                return knownPicoSwanDeviceModels.Contains(DeviceModel)
+                    || DeviceProduct.Equals("swan", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
         // OCULUS DEVICE DETECTION
         /// <summary>
         /// Returns true if the current device is Oculus Quest 1
@@ -263,7 +280,7 @@ namespace MXR.SDK {
             IsQuestPro || IsQuest1 || IsQuest2 || IsQuest3 || IsQuest3S ||
 
             // Pico headsets
-            IsPico4Ultra || IsPico4 || IsPicoNeo3 || IsPicoNeo2 ||
+            IsPicoSwan || IsPico4Ultra || IsPico4 || IsPicoNeo3 || IsPicoNeo2 ||
 
             // HTC Headsets
             IsHTCViveFlow || IsHTCViveFocus3 || IsHTCViveFocusPlus || IsHTCViveXRSeries || IsHTCViveFocusVision;

--- a/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs
+++ b/Assets/MXR.SDK/Runtime/Android/Utils/MXRPicoUtils.cs
@@ -46,11 +46,14 @@ namespace MXR.SDK {
         }
 
         /// <summary>
-        /// Returns if current Pico UI version is 5.x.x 
+        /// Returns if current Pico UI version is 5.x.x
         /// Always returns false on non Pico device
         /// </summary>
         public static bool IsPUI5 {
             get {
+                // Swan reports Build.DISPLAY = "0.x" today but its ToBService is API-compatible
+                // with the 4.3.x AAR line used by PUI 5+ devices. Treat as PUI 5 for routing.
+                if (MXRAndroidUtils.IsPicoSwan) return true;
                 if(MXRAndroidUtils.IsPicoDevice)
                     return PUIVersion.StartsWith("5");
                 else {
@@ -86,6 +89,9 @@ namespace MXR.SDK {
                     Debug.unityLogger.LogWarning(TAG, "Not running on a Pico device. MXRPicoUtils.IsKioskRebootRequiredforPUI returning false");
                     return false;
                 }
+
+                // Swan is ToB-compat with PUI 5.11+ semantics — no reboot required on kiosk toggle.
+                if (MXRAndroidUtils.IsPicoSwan) return false;
 
                 if (IsPUI4) return false;
 


### PR DESCRIPTION
## Pico Swan Device Detection and PUI Routing Support

Adds detection for the Pico Swan (model `B3110` / product `swan`) headset, mirroring the model and product identifiers used in mighty-admin-app. The Swan is included in the known supported headset check alongside other Pico devices.

Since the Swan reports `Build.DISPLAY = "0.x"` but its ToBService is API-compatible with the PUI 5 (4.3.x AAR) line, `IsPUI5` returns `true` for Swan devices to ensure correct service routing. Additionally, kiosk reboot is not required on Swan, consistent with PUI 5.11+ semantics.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Testing
- [ ] Unity tests pass (if applicable)
- [ ] Tested on device (if applicable)

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed
- [ ] Documentation updated (if needed)