### PR TITLE
ENG-2351: Fix DeserializeFromFile false-success on 0-byte cache

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Initialization.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Initialization.cs
@@ -172,7 +172,32 @@ namespace MXR.SDK {
                 }
 
                 contents = File.ReadAllText(filePath);
+
+                // ENG-2351: Newtonsoft's JsonConvert.DeserializeObject<T>("")
+                // returns null without throwing, so the catch below never fires
+                // and DeserializeFromFile would return true with value = null.
+                // Treat empty contents as a cache miss so the caller falls
+                // through to the IPC RefreshDeviceData/Status/RuntimeSettings
+                // path. This is the dominant ENG-1990 customer hang trigger:
+                // a 0-byte cache file existing on disk (left behind by an
+                // unclean shutdown mid-write, etc.) was being accepted as a
+                // successful init, locking the SDK with null state forever.
+                if (string.IsNullOrWhiteSpace(contents)) {
+                    contents = null;
+                    value = default;
+                    return false;
+                }
+
                 value = JsonConvert.DeserializeObject<T>(contents);
+
+                // Defense in depth: even with non-empty contents, Newtonsoft
+                // may produce null for malformed-but-recoverable input (e.g.
+                // "null", "  "). Same recovery path.
+                if (value == null) {
+                    contents = null;
+                    return false;
+                }
+
                 return true;
             } catch (Exception e) {
                 LogIfEnabled(e);


### PR DESCRIPTION
## Summary
- `DeserializeFromFile<T>` was returning `true` with `value = null` when the cache file existed but was empty or contained content Newtonsoft silently deserializes to null (notably: 0-byte files and files filled with NULL bytes, both observed in the field).
- This caused `InitializeDeviceData` to early-return on a false-success, skipping the Method 2 IPC fallback that would have recovered the SDK. `MXRManager.InitAsync` then polled `System.DeviceData == null` forever and HS hung indefinitely at the `MXRHasData` boot gate — the dominant ENG-1990 customer-reported "black screen + white gaze dot" symptom.
- Adds two early-return guards inside the existing `try` block: `string.IsNullOrWhiteSpace(contents)` and a post-deserialize `value == null` check. Both make the caller fall through to the IPC fallback path that was already in place but unreachable.

## Linear
[ENG-2351: MXR.SDK: DeserializeFromFile treats null deserialize as success, blocking IPC fallback (ENG-1990 root cause)](https://linear.app/managexr/issue/ENG-2351)

Parent: [ENG-1990](https://linear.app/managexr/issue/ENG-1990).
Sibling of ENG-2319 (this PR stacks on #246) — atomic writes prevent *creating* 0-byte caches via mid-write kills; this null-check recovers *from* them for devices already in the broken state (which all currently-stuck customer devices are).

## Test plan
Validated end-to-end on Pico 4UE (`PA94Y0MGJA240278G`) with a local Unity build of HS develop + this SDK branch:

**Test 1 — 0-byte cache (synthetic):**
- ` adb shell am force-stop <hs>`
- `adb shell "echo -n '' > /sdcard/Android/data/<hs>/files/ManageXR/deviceData.json"`
- Relaunch HS. **Expected:** boot reaches Launcher in <1s; SDK logs `Cannot initialize DeviceData using cached json file` → `Invoking RefreshDeviceData to initialize DeviceData using MXR Admin App`. ✅ PASS (845ms from init to Launcher scene load).

**Test 2 — 1455 bytes of NULL (matches actual stuck-customer file from a Quest log bundle):**
- `adb shell dd if=/dev/zero of=/sdcard/Android/data/<hs>/files/ManageXR/deviceData.json bs=1 count=1455`
- Relaunch HS. **Expected:** same recovery path. ✅ PASS (12ms between cache read and patch deciding to fall through; no JsonReaderException — proves the `value == null` guard is what catches the customer case, not the existing try/catch).

**Pre-patch repro (control):**
- Same HS + AA versions without this patch on the same device hangs indefinitely. AA observed receiving only one `REGISTER_CLIENT (type 0)` from HS and zero `GET_DEVICE_DATA (type 19)` requests for the entire stuck-state lifetime, confirming the SDK never fires the IPC fallback.

## Notes for reviewer
- The fix is intentionally inside `DeserializeFromFile<T>` (the shared helper) rather than each `Initialize*` method, so DeviceStatus and RuntimeSettingsSummary get the same guard. Any of the three cache files hitting this state would otherwise hang the boot gate the same way.
- No behavior change for valid cache content — the new guards are only reached when contents are blank/whitespace or when deserialize silently returns null.