### PR TITLE
Bump version to 1.0.57

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.56",
+	"version": "1.0.57",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
## Summary
Bumps the SDK package version from 1.0.56 → 1.0.57. This release bundles two bugfixes related to ENG-1990:

- **ENG-2319** (#246) — Atomic writes for cached state files (prevents creating 0-byte caches via mid-write kills)
- **ENG-2351** (#247) — Fix `DeserializeFromFile` false-success on 0-byte / NULL-byte cache (recovers from existing 0-byte and all-NULL cache files; this is the ENG-1990 customer-facing fix)