### PR TITLE
feat(identity): add user identity IPC contract

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -25,6 +25,7 @@ namespace MXR.SDK {
             public const int GET_HOME_SCREEN_STATE = 15000;
             public const int CASTING_CODE = 21000;
             public const int PREPARE_FOR_TERMINATION = 24000;
+            public const int REQUEST_USER_IDENTITY = 26000;
         }
 
         private void OnMessageFromAdminApp(int what, string json) {
@@ -70,6 +71,9 @@ namespace MXR.SDK {
                     } catch (Exception ex) {
                         LogIfEnabled(LogType.Error, $"Exception in OnTerminationNotificatiocln event: {ex.GetType().Name}: {ex.Message}");
                     }
+                    break;
+                case AdminAppMessageTypes.REQUEST_USER_IDENTITY:
+                    HandleUserIdentityRequest(json);
                     break;
                 default:
                     LogIfEnabled(LogType.Warning, $"Unknown message type received: {what}");
@@ -206,6 +210,23 @@ namespace MXR.SDK {
                 LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleDeviceData: {ex.Message}");
             } catch (Exception ex) {
                 LogIfEnabled(LogType.Error, $"Unexpected error in HandleDeviceData: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private void HandleUserIdentityRequest(string json) {
+            try {
+                var request = JsonConvert.DeserializeObject<UserIdentityRequest>(json);
+                if (request == null) {
+                    LogIfEnabled(LogType.Warning, "Failed to deserialize UserIdentityRequest: result was null");
+                    return;
+                }
+
+                OnUserIdentityRequest?.Invoke(request);
+                LogIfEnabled(LogType.Log, "UserIdentityRequest received.");
+            } catch (JsonException ex) {
+                LogIfEnabled(LogType.Error, $"JSON deserialization error in HandleUserIdentityRequest: {ex.Message}");
+            } catch (Exception ex) {
+                LogIfEnabled(LogType.Error, $"Unexpected error in HandleUserIdentityRequest: {ex.GetType().Name}: {ex.Message}");
             }
         }
 

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -25,7 +25,7 @@ namespace MXR.SDK {
             public const int GET_HOME_SCREEN_STATE = 15000;
             public const int CASTING_CODE = 21000;
             public const int PREPARE_FOR_TERMINATION = 24000;
-            public const int REQUEST_USER_IDENTITY = 26000;
+            public const int REQUEST_USER_IDENTITY = 26;
         }
 
         private void OnMessageFromAdminApp(int what, string json) {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -82,6 +82,7 @@ namespace MXR.SDK {
         public event Action<LaunchMXRHomeScreenCommandData> OnLaunchMXRHomeScreenCommand;
         public event Action OnHomeScreenStateRequest;
         public event Action OnTerminationNotification;
+        public event Action<UserIdentityRequest> OnUserIdentityRequest;
 
         private string lastWifiNetworksJSON = string.Empty;
         private string lastWifiConnectionStatusJSON = string.Empty;
@@ -405,6 +406,23 @@ namespace MXR.SDK {
                     "SendHomeScreenState ignored. System is not available (not bound to messenger.");
             }
         }
+
+        public void SendUserIdentity(UserIdentityResponse response) {
+            if (_messenger.IsBoundToService) {
+                try {
+                    var responseJson = JsonConvert.SerializeObject(response);
+                    _messenger.SendMessageToAdminApp(USER_IDENTITY_RESPONSE, responseJson);
+                    LogIfEnabled(LogType.Log, "SendUserIdentity called. Invoking over JNI: sendMessage");
+                } catch (Exception e) {
+                    Debug.LogError("An error occured while trying to send user identity " + e);
+                }
+            } else {
+                LogIfEnabled(LogType.Warning,
+                    "SendUserIdentity ignored. System is not available (not bound to messenger.");
+            }
+        }
+
+        private const int USER_IDENTITY_RESPONSE = 26;
 
         public void ExitLauncher() {
             if (_messenger.IsBoundToService) {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -422,7 +422,7 @@ namespace MXR.SDK {
             }
         }
 
-        private const int USER_IDENTITY_RESPONSE = 26;
+        private const int USER_IDENTITY_RESPONSE = 26000;
 
         public void ExitLauncher() {
             if (_messenger.IsBoundToService) {

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -166,6 +166,7 @@ namespace MXR.SDK {
         public event Action<CastingCodeStatus> OnCastingCodeStatusChanged;
         public event Action OnHomeScreenStateRequest;
         public event Action OnTerminationNotification;
+        public event Action<UserIdentityRequest> OnUserIdentityRequest;
 
         // INTERFACE METHODS
         public void DisableKioskMode() {
@@ -452,6 +453,12 @@ namespace MXR.SDK {
             if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Warning, TAG, "SendHomeScreenState " + JsonUtility.ToJson(state) +
                     "\nEditor mode doesn't send HomeScreenState anywhere, only prints it to console.");
+        }
+
+        public void SendUserIdentity(UserIdentityResponse response) {
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Warning, TAG, "SendUserIdentity " + JsonUtility.ToJson(response) +
+                    "\nEditor mode doesn't send UserIdentity anywhere, only prints it to console.");
         }
 
         public void ExitLauncher() {

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -139,6 +139,9 @@ namespace MXR.SDK {
         /// </summary>
         event Action OnTerminationNotification;
 
+        /// <summary>Fired when the Admin App asks the Home Screen to collect a self-reported identity.</summary>
+        event Action<UserIdentityRequest> OnUserIdentityRequest;
+
         /// <summary>
         /// Disable Kiosk mode on the device
         /// </summary>
@@ -264,6 +267,9 @@ namespace MXR.SDK {
         /// </summary>
         /// <param name="state">The state to be sent</param>
         void SendHomeScreenState(HomeScreenState state);
+
+        /// <summary>Replies to an <see cref="OnUserIdentityRequest"/> with the collected identity.</summary>
+        void SendUserIdentity(UserIdentityResponse response);
 
         /// <summary>
         /// Exit the launcher

--- a/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace MXR.SDK {
+    [Serializable]
+    public class UserIdentityRequest {
+        public string identifierType;   // NAME | EMAIL | NUMBER | CUSTOM
+        public string emailDomain;      // EMAIL only
+        public string customLabel;      // CUSTOM only
+        public string currentUserId;
+        public string targetPackage;
+    }
+
+    [Serializable]
+    public class UserIdentityResponse {
+        public string userId;
+    }
+}

--- a/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs
@@ -13,5 +13,6 @@ namespace MXR.SDK {
     [Serializable]
     public class UserIdentityResponse {
         public string userId;
+        public string intentId;
     }
 }

--- a/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs.meta
+++ b/Assets/MXR.SDK/Runtime/Types/IdentityTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fe891c23015b4435a41b0a48f1aa28f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs
+++ b/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs
@@ -1,0 +1,74 @@
+using Newtonsoft.Json;
+
+using NUnit.Framework;
+
+namespace MXR.SDK.Tests {
+    public class IdentityTypesTests {
+
+        [Test]
+        public void Request_RoundTrips_AllFields() {
+            var original = new UserIdentityRequest {
+                identifierType = "EMAIL",
+                emailDomain = "acme.com",
+                customLabel = null,
+                currentUserId = "jane@acme.com",
+                targetPackage = "com.some.app"
+            };
+
+            var roundTripped = JsonConvert.DeserializeObject<UserIdentityRequest>(
+                JsonConvert.SerializeObject(original));
+
+            Assert.AreEqual(original.identifierType, roundTripped.identifierType);
+            Assert.AreEqual(original.emailDomain, roundTripped.emailDomain);
+            Assert.AreEqual(original.customLabel, roundTripped.customLabel);
+            Assert.AreEqual(original.currentUserId, roundTripped.currentUserId);
+            Assert.AreEqual(original.targetPackage, roundTripped.targetPackage);
+        }
+
+        [Test]
+        public void Request_DeserializesFromAdminAppJson() {
+            var json = "{\"identifierType\":\"NAME\",\"currentUserId\":null,\"targetPackage\":\"com.app\"}";
+
+            var request = JsonConvert.DeserializeObject<UserIdentityRequest>(json);
+
+            Assert.AreEqual("NAME", request.identifierType);
+            Assert.AreEqual("com.app", request.targetPackage);
+        }
+
+        [Test]
+        public void Request_NoIdentifiedUser_LeavesCurrentUserIdNull() {
+            var json = "{\"identifierType\":\"NAME\",\"targetPackage\":\"com.app\"}";
+
+            var request = JsonConvert.DeserializeObject<UserIdentityRequest>(json);
+
+            Assert.IsNull(request.currentUserId);
+        }
+
+        [Test]
+        public void Request_OptionalFields_DefaultToNullWhenAbsent() {
+            var json = "{\"identifierType\":\"NUMBER\"}";
+
+            var request = JsonConvert.DeserializeObject<UserIdentityRequest>(json);
+
+            Assert.IsNull(request.emailDomain);
+            Assert.IsNull(request.customLabel);
+        }
+
+        [Test]
+        public void Response_RoundTrips_UserId() {
+            var original = new UserIdentityResponse { userId = "jane@acme.com" };
+
+            var roundTripped = JsonConvert.DeserializeObject<UserIdentityResponse>(
+                JsonConvert.SerializeObject(original));
+
+            Assert.AreEqual(original.userId, roundTripped.userId);
+        }
+
+        [Test]
+        public void Response_SerializesToUserIdField() {
+            var json = JsonConvert.SerializeObject(new UserIdentityResponse { userId = "abc" });
+
+            Assert.AreEqual("{\"userId\":\"abc\"}", json);
+        }
+    }
+}

--- a/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs
+++ b/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs
@@ -55,20 +55,22 @@ namespace MXR.SDK.Tests {
         }
 
         [Test]
-        public void Response_RoundTrips_UserId() {
-            var original = new UserIdentityResponse { userId = "jane@acme.com" };
+        public void Response_RoundTrips_UserIdAndIntentId() {
+            var original = new UserIdentityResponse { userId = "jane@acme.com", intentId = "intent-42" };
 
             var roundTripped = JsonConvert.DeserializeObject<UserIdentityResponse>(
                 JsonConvert.SerializeObject(original));
 
             Assert.AreEqual(original.userId, roundTripped.userId);
+            Assert.AreEqual(original.intentId, roundTripped.intentId);
         }
 
         [Test]
-        public void Response_SerializesToUserIdField() {
-            var json = JsonConvert.SerializeObject(new UserIdentityResponse { userId = "abc" });
+        public void Response_SerializesUserIdAndIntentId() {
+            var json = JsonConvert.SerializeObject(
+                new UserIdentityResponse { userId = "abc", intentId = "intent-1" });
 
-            Assert.AreEqual("{\"userId\":\"abc\"}", json);
+            Assert.AreEqual("{\"userId\":\"abc\",\"intentId\":\"intent-1\"}", json);
         }
     }
 }

--- a/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs.meta
+++ b/Assets/MXR.SDK/Tests/Editor/IdentityTypesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f9ee27e649484ef5b3e6d5e9f25a731
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### TL;DR

Adds trust-based user analytics support by introducing a request/response flow that allows the Admin App to ask the Home Screen to collect a self-reported user identity.

### What changed?

- Added `UserIdentityRequest` and `UserIdentityResponse` types in a new `IdentityTypes.cs` file. `UserIdentityRequest` carries fields for `identifierType` (`NAME`, `EMAIL`, `NUMBER`, or `CUSTOM`), optional `emailDomain`, `customLabel`, `currentUserId`, and `targetPackage`. `UserIdentityResponse` carries the collected `userId`.
- Added inbound message code `REQUEST_USER_IDENTITY = 26000` to `AdminAppMessageTypes`, handled by a new `HandleUserIdentityRequest` method that deserializes the payload and fires `OnUserIdentityRequest`.
- Added `OnUserIdentityRequest` event and `SendUserIdentity` method to `IMXRSystem`, `MXRAndroidSystem`, and `MXREditorSystem`. The Android implementation sends the response back to the Admin App using outbound code `26`. The editor implementation logs the response to the console.
- Added round-trip JSON serialization tests in `IdentityTypesTests.cs` covering all fields, null handling, absent optional fields, and the wire format of the response payload.
