### PR TITLE
Bump version to 1.0.59

### DIFF
--- a/Assets/MXR.SDK/package.json
+++ b/Assets/MXR.SDK/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.mxr.unity.sdk",
-	"version": "1.0.58",
+	"version": "1.0.59",
 	"displayName": "ManageXR Unity SDK",
 	"description": "ManageXR Android and Editor System and Utilities for integrating with the ManageXR MDM platform.",
 	"unity": "2019.4",


### PR DESCRIPTION
## Summary
Bump the SDK package version to **1.0.59** to cut the release that includes the user-identity IPC contract (#249 / ENG-2555).

Merge order: land #249 first (or either order — no file overlap; this only touches `package.json`), then this, then tag `v1.0.59` from master.

## Type of Change
- [x] Other (version bump / release)

## Testing
- [x] Version-only change; no code affected