### PR TITLE
refactor(identity): group USER_IDENTITY_RESPONSE with the other message codes

### DIFF
--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.Messages.cs
@@ -26,6 +26,7 @@ namespace MXR.SDK {
             public const int CASTING_CODE = 21000;
             public const int PREPARE_FOR_TERMINATION = 24000;
             public const int REQUEST_USER_IDENTITY = 26;
+            public const int USER_IDENTITY_RESPONSE = 26000;
         }
 
         private void OnMessageFromAdminApp(int what, string json) {

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -411,7 +411,7 @@ namespace MXR.SDK {
             if (_messenger.IsBoundToService) {
                 try {
                     var responseJson = JsonConvert.SerializeObject(response);
-                    _messenger.SendMessageToAdminApp(USER_IDENTITY_RESPONSE, responseJson);
+                    _messenger.SendMessageToAdminApp(AdminAppMessageTypes.USER_IDENTITY_RESPONSE, responseJson);
                     LogIfEnabled(LogType.Log, "SendUserIdentity called. Invoking over JNI: sendMessage");
                 } catch (Exception e) {
                     Debug.LogError("An error occured while trying to send user identity " + e);
@@ -421,8 +421,6 @@ namespace MXR.SDK {
                     "SendUserIdentity ignored. System is not available (not bound to messenger.");
             }
         }
-
-        private const int USER_IDENTITY_RESPONSE = 26000;
 
         public void ExitLauncher() {
             if (_messenger.IsBoundToService) {


### PR DESCRIPTION
Per Vatsal's review on #249: move the outbound `USER_IDENTITY_RESPONSE` constant into `AdminAppMessageTypes` next to `REQUEST_USER_IDENTITY`, rather than a lone const beside `SendUserIdentity`. No behavior change (value stays 26000).