### PR TITLE
ENG-3240: feat: Add analytics event IPC and C# API

### DIFF
--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessageTypes.java
@@ -62,4 +62,6 @@ public class AdminAppMessageTypes {
     public static final int RETRY_APP_DOWNLOAD = 25;
 
     public static final int RETRY_APP_DOWNLOADS = 26;
+
+    public static final int LOG_ANALYTICS_EVENT = 29;
 }

--- a/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
+++ b/Assets/MXR.SDK/Plugins/Android/AdminAppMessengerManager.java
@@ -243,6 +243,10 @@ public class AdminAppMessengerManager {
         return sendMessage(AdminAppMessageTypes.UPLOAD_DEVICE_LOGS);
     }
 
+    public boolean sendAnalyticsEventAsync(String eventJson) {
+        return sendMessage(AdminAppMessageTypes.LOG_ANALYTICS_EVENT, eventJson);
+    }
+
     public boolean sendMessage(int what) {
         return sendMessage(what, null);
     }

--- a/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Android/MXRAndroidSystem.cs
@@ -422,6 +422,19 @@ namespace MXR.SDK {
             }
         }
 
+        public void SendAnalyticsEvent(string eventJson) {
+            if (_messenger.IsBoundToService) {
+                try {
+                    _messenger.Call<bool>("sendAnalyticsEventAsync", eventJson);
+                    LogIfEnabled(LogType.Log, "SendAnalyticsEvent sent.");
+                } catch (Exception e) {
+                    Debug.LogError($"SendAnalyticsEvent failed: {e}");
+                }
+            } else {
+                LogIfEnabled(LogType.Warning, "SendAnalyticsEvent ignored. Messenger not bound.");
+            }
+        }
+
         public void ExitLauncher() {
             if (_messenger.IsBoundToService) {
                 LogIfEnabled(LogType.Log, "ExitLauncher called. Invoking over JNI: exitLauncherAsync");

--- a/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
+++ b/Assets/MXR.SDK/Runtime/Editor/MXREditorSystem.cs
@@ -461,6 +461,13 @@ namespace MXR.SDK {
                     "\nEditor mode doesn't send UserIdentity anywhere, only prints it to console.");
         }
 
+        public void SendAnalyticsEvent(string eventJson) {
+            if (LoggingEnabled)
+                Debug.unityLogger.Log(LogType.Log, TAG,
+                    "SendAnalyticsEvent " + eventJson +
+                    "\nEditor mode doesn't send analytics events anywhere, only prints the payload to console.");
+        }
+
         public void ExitLauncher() {
             if (LoggingEnabled)
                 Debug.unityLogger.Log(LogType.Log, TAG, "Editor mode doesn't support ExitLauncher(). Safely ignored...");

--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -272,6 +272,24 @@ namespace MXR.SDK {
         void SendUserIdentity(UserIdentityResponse response);
 
         /// <summary>
+        /// Send an analytics event to the Admin App.
+        /// You can build the JSON string with <see cref="AnalyticsEventPayload.ToJson"/>
+        /// </summary>
+        /// <param name="eventJson">
+        /// Analytics event payload as JSON: 
+        /// <c>
+        /// { 
+        ///   "name" : "name", 
+        ///   "properties" : { 
+        ///     "prop1": value,
+        ///     "prop2": value
+        ///   } 
+        /// }
+        /// </c>
+        /// </param>
+        void SendAnalyticsEvent(string eventJson);
+
+        /// <summary>
         /// Exit the launcher
         /// </summary>
         void ExitLauncher();

--- a/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+namespace MXR.SDK {
+    /// <summary>
+    /// Generic analytics event envelope sent from Home Screen to Admin App.
+    /// Serializes to <c>{ "name": "...", "properties": { ... } }</c>.
+    /// </summary>
+    public class AnalyticsEventPayload {
+        public string name;
+        public Dictionary<string, object> properties;
+
+        /// <summary>
+        /// Serializes this payload to the JSON wire format expected by
+        /// <see cref="IMXRSystem.SendAnalyticsEvent(string)"/>.
+        /// </summary>
+        public string ToJson() => JsonConvert.SerializeObject(this);
+    }
+}

--- a/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs.meta
+++ b/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3c8e1f42b9d4e6a8f0c2d5e7b1a3948
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs
+++ b/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+using NUnit.Framework;
+
+namespace MXR.SDK.Tests {
+    public class AnalyticsTypeTests {
+
+        static AnalyticsEventPayload CreateVideoPlaybackStoppedPayload() =>
+            new AnalyticsEventPayload {
+                name = "video_playback_stopped",
+                properties = new Dictionary<string, object> {
+                    ["videoId"] = "abc123",
+                    ["videoTitle"] = "Test video",
+                    ["sessionId"] = "550e8400-e29b-41d4-a716-446655440000",
+                    ["segmentIndex"] = 0,
+                    ["segmentEventId"] = "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+                    ["startTime"] = 1720000000000L,
+                    ["endTime"] = 1720000120000L,
+                    ["duration"] = 120000L,
+                    ["videoDurationMs"] = 600000L,
+                    ["endReason"] = "paused",
+                    ["replayIndex"] = 0,
+                }
+            };
+
+        [Test]
+        public void Serialize_SerializesEventName() {
+            var json = JsonConvert.SerializeObject(CreateVideoPlaybackStoppedPayload());
+            var payload = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+
+            Assert.AreEqual("video_playback_stopped", payload.name);
+        }
+
+        [Test]
+        public void Serialize_SerializesVideoPlaybackStoppedProperties() {
+            var json = JsonConvert.SerializeObject(CreateVideoPlaybackStoppedPayload());
+            var payload = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+            var properties = payload.properties;
+
+            Assert.NotNull(properties);
+            Assert.AreEqual("abc123", properties["videoId"]);
+            Assert.AreEqual("Test video", properties["videoTitle"]);
+            Assert.AreEqual("550e8400-e29b-41d4-a716-446655440000", properties["sessionId"]);
+            Assert.AreEqual(0, Convert.ToInt32(properties["segmentIndex"]));
+            Assert.AreEqual("7c9e6679-7425-40de-944b-e07fc1f90ae7", properties["segmentEventId"]);
+            Assert.AreEqual(1720000000000L, Convert.ToInt64(properties["startTime"]));
+            Assert.AreEqual(1720000120000L, Convert.ToInt64(properties["endTime"]));
+            Assert.AreEqual(120000L, Convert.ToInt64(properties["duration"]));
+            Assert.AreEqual(600000L, Convert.ToInt64(properties["videoDurationMs"]));
+            Assert.AreEqual("paused", properties["endReason"]);
+            Assert.AreEqual(0, Convert.ToInt32(properties["replayIndex"]));
+        }
+
+        [Test]
+        public void Serialize_DurationEqualsEndTimeMinusStartTime() {
+            var json = JsonConvert.SerializeObject(CreateVideoPlaybackStoppedPayload());
+            var payload = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+            var properties = payload.properties;
+
+            var startTime = Convert.ToInt64(properties["startTime"]);
+            var endTime = Convert.ToInt64(properties["endTime"]);
+            var duration = Convert.ToInt64(properties["duration"]);
+
+            Assert.AreEqual(endTime - startTime, duration);
+        }
+
+        [Test]
+        public void ToJson_MatchesJsonConvertSerializeObject() {
+            var payload = CreateVideoPlaybackStoppedPayload();
+
+            Assert.AreEqual(JsonConvert.SerializeObject(payload), payload.ToJson());
+        }
+
+        [Test]
+        public void Deserialize_RoundTrips_NameAndProperties() {
+            var original = CreateVideoPlaybackStoppedPayload();
+            var json = JsonConvert.SerializeObject(original);
+
+            var roundTripped = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+
+            Assert.AreEqual(original.name, roundTripped.name);
+            Assert.AreEqual(original.properties.Count, roundTripped.properties.Count);
+            Assert.AreEqual(original.properties["videoId"], roundTripped.properties["videoId"]);
+            Assert.AreEqual(original.properties["endReason"], roundTripped.properties["endReason"]);
+            Assert.AreEqual(Convert.ToInt64(original.properties["duration"]),
+                Convert.ToInt64(roundTripped.properties["duration"]));
+        }
+
+        [Test]
+        public void Deserialize_FromWireFormatJson() {
+            const string json =
+                "{\"name\":\"video_playback_stopped\",\"properties\":{\"videoId\":\"abc123\",\"videoTitle\":\"Test video\",\"sessionId\":\"550e8400-e29b-41d4-a716-446655440000\",\"segmentIndex\":0,\"segmentEventId\":\"7c9e6679-7425-40de-944b-e07fc1f90ae7\",\"startTime\":1720000000000,\"endTime\":1720000120000,\"duration\":120000,\"videoDurationMs\":600000,\"endReason\":\"paused\",\"replayIndex\":0}}";
+
+            var payload = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+
+            Assert.AreEqual("video_playback_stopped", payload.name);
+            Assert.AreEqual("abc123", payload.properties["videoId"]);
+            Assert.AreEqual("paused", payload.properties["endReason"]);
+        }
+    }
+}

--- a/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs.meta
+++ b/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8d4f2a91c3e4d7f9a2b6c8e0d1f4a63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## **ENG-3240: feat: Add analytics event IPC and C# API**

Introduces the functionality to send structured analytics events from the MXR SDK to the Admin App.

This change includes: 

\- A new inter-process communication (IPC) message type (`LOG_ANALYTICS_EVENT`).   
\- An Android messenger method (`sendAnalyticsEventAsync`) to dispatch the event payload.   
\- A public C# SDK API (`IMXRSystem.SendAnalyticsEvent`) and its Android and Editor implementations.   
\- A new `AnalyticsEventPayload` helper class for constructing JSON event data.   
\- Unit tests for `AnalyticsEventPayload` serialization.