### PR TITLE
ENG-3702: Add optional eventId to the analytics envelope

### DIFF
--- a/Assets/MXR.SDK/Runtime/IMXRSystem.cs
+++ b/Assets/MXR.SDK/Runtime/IMXRSystem.cs
@@ -276,16 +276,18 @@ namespace MXR.SDK {
         /// You can build the JSON string with <see cref="AnalyticsEventPayload.ToJson"/>
         /// </summary>
         /// <param name="eventJson">
-        /// Analytics event payload as JSON: 
+        /// Analytics event payload as JSON:
         /// <c>
-        /// { 
-        ///   "name" : "name", 
-        ///   "properties" : { 
+        /// {
+        ///   "name" : "name",
+        ///   "properties" : {
         ///     "prop1": value,
         ///     "prop2": value
-        ///   } 
+        ///   },
+        ///   "eventId" : "optional uuid"
         /// }
         /// </c>
+        /// <c>eventId</c> is optional. A well-formed UUID makes the send idempotent.
         /// </param>
         void SendAnalyticsEvent(string eventJson);
 

--- a/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs
+++ b/Assets/MXR.SDK/Runtime/Types/AnalyticsTypes.cs
@@ -5,11 +5,19 @@ using Newtonsoft.Json;
 namespace MXR.SDK {
     /// <summary>
     /// Generic analytics event envelope sent from Home Screen to Admin App.
-    /// Serializes to <c>{ "name": "...", "properties": { ... } }</c>.
+    /// Serializes to <c>{ "name": "...", "properties": { ... } }</c>, plus
+    /// <c>"eventId"</c> when one is set.
     /// </summary>
     public class AnalyticsEventPayload {
         public string name;
         public Dictionary<string, object> properties;
+
+        /// <summary>
+        /// Optional idempotency key. Admin App adopts a well-formed UUID as the event's
+        /// eventUUID, so replays dedupe. One id per emission, not per logical event.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string eventId;
 
         /// <summary>
         /// Serializes this payload to the JSON wire format expected by

--- a/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs
+++ b/Assets/MXR.SDK/Tests/Editor/AnalyticsTypeTests.cs
@@ -99,6 +99,54 @@ namespace MXR.SDK.Tests {
             Assert.AreEqual("video_playback_stopped", payload.name);
             Assert.AreEqual("abc123", payload.properties["videoId"]);
             Assert.AreEqual("paused", payload.properties["endReason"]);
+            Assert.IsNull(payload.eventId);
+        }
+
+        [Test]
+        public void Serialize_OmitsEventId_WhenNotSet() {
+            var json = JsonConvert.SerializeObject(CreateVideoPlaybackStoppedPayload());
+
+            Assert.IsFalse(json.Contains("eventId"));
+        }
+
+        [Test]
+        public void Serialize_IncludesEventId_WhenSet() {
+            var payload = CreateVideoPlaybackStoppedPayload();
+            payload.eventId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+
+            var json = JsonConvert.SerializeObject(payload);
+
+            StringAssert.Contains("\"eventId\":\"3f2504e0-4f89-11d3-9a0c-0305e82c3301\"", json);
+        }
+
+        [Test]
+        public void ToJson_MatchesJsonConvertSerializeObject_WithEventId() {
+            var payload = CreateVideoPlaybackStoppedPayload();
+            payload.eventId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+
+            Assert.AreEqual(JsonConvert.SerializeObject(payload), payload.ToJson());
+        }
+
+        [Test]
+        public void Deserialize_RoundTrips_EventId() {
+            var original = CreateVideoPlaybackStoppedPayload();
+            original.eventId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+            var json = JsonConvert.SerializeObject(original);
+
+            var roundTripped = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+
+            Assert.AreEqual(original.eventId, roundTripped.eventId);
+        }
+
+        [Test]
+        public void Deserialize_FromWireFormatJson_WithEventId() {
+            const string json =
+                "{\"name\":\"video_playback_stopped\",\"properties\":{\"videoId\":\"abc123\"},\"eventId\":\"3f2504e0-4f89-11d3-9a0c-0305e82c3301\"}";
+
+            var payload = JsonConvert.DeserializeObject<AnalyticsEventPayload>(json);
+
+            Assert.AreEqual("video_playback_stopped", payload.name);
+            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", payload.eventId);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds an optional `eventId` to `AnalyticsEventPayload`. Serialized only when set, via `NullValueHandling.Ignore`, so every existing sender produces byte-identical JSON.
- Documents the field on `IMXRSystem.SendAnalyticsEvent`, including the rule that an `eventId` identifies one **emission**, not one logical event.
- Five new cases in `AnalyticsTypeTests`.

Admin App already reads this field. `AnalyticsIpcReceiver` adopts a well-formed UUID as the device event's `eventUUID`, so a replayed emission collapses with the original under the existing `DISTINCT ON (eventUUID)` dedupe. The envelope had no field to carry one, so Home Screen could not supply it.

## Why now

Measured on a Pico 4 Ultra Enterprise. A planned reboot mid-video produced two identical `video_playback_stopped` rows in Admin App for one clip, 80 seconds apart:

```
19:04:58.460  clipEventId=d51e3a6f-0ceb-49f6-a3c6-e50fc0a13453  clipDurationMs=46786  interrupted
19:06:18.830  clipEventId=d51e3a6f-0ceb-49f6-a3c6-e50fc0a13453  clipDurationMs=46786  interrupted
```

46.8 seconds watched, 93.6 seconds reported. The second send is the deliberate boot-recovery replay; it is supposed to dedupe against the first and cannot without this field.

## Admin App behaviour this targets

Verified against `AnalyticsIpcReceiver` on the Admin App default branch:

| Wire | Result |
| --- | --- |
| `eventId` absent | random `eventUUID`, no warning |
| `eventId` JSON null | not a JSON primitive, so random `eventUUID`, no warning |
| well-formed UUID string | `eventUUID = eventId` |
| malformed string | warns, falls back to a random `eventUUID` |

Omitting the field when null is therefore safe for old and new senders alike.

## Test plan

`AnalyticsTypeTests` passes 11 of 11 in EditMode, including the five new cases:

- `Serialize_OmitsEventId_WhenNotSet`
- `Serialize_IncludesEventId_WhenSet`
- `ToJson_MatchesJsonConvertSerializeObject_WithEventId`
- `Deserialize_RoundTrips_EventId`
- `Deserialize_FromWireFormatJson_WithEventId`

Two caveats a reviewer should know:

1. **This repository has no test CI.** `ci.yml` triggers only on push to `master` and runs the OpenUPM release. No job runs these tests on a pull request, so the result above comes from a local run and will not be reproduced by CI.
2. The project targets Unity `2019.4.40f1`, which was not available on the machine used. The tests were run under `2021.3.35f1` in a scratch worktree, so the resulting project upgrade is not part of this branch. Worth a second run on 2019.4 before merge if that matters to you.

## Follow-up, not in this PR

The Home Screen side still has to mint an `eventId` per emission, persist it in the pending-clip snapshot before the first send, and reuse it verbatim on the boot replay. Tracked separately. Adding the field alone changes no behaviour.
